### PR TITLE
Fix check-in errors: scoring upload override and week finalization

### DIFF
--- a/backend/manage.py
+++ b/backend/manage.py
@@ -6,10 +6,12 @@ handler, eliminating the need for every test to trigger the seeder.
 """
 
 import click
+from datetime import datetime, timezone
 
 from .database import SessionLocal, engine, Base
 from .scripts.seed import run_seeder
 from .scripts.audit_player_duplicates import run_audit as run_player_duplicate_audit
+from .scripts.finalize_week import run_finalization
 from .core.security import get_password_hash
 
 
@@ -59,6 +61,36 @@ def audit_player_duplicates(apply_changes: bool, fail_on_duplicates: bool, json_
         raise click.ClickException(
             f"Found {summary['duplicate_groups']} duplicate player groups"
         )
+
+
+@cli.command("finalize-week")
+@click.option("--league-id", type=int, required=True, help="Target league ID.")
+@click.option("--week", type=int, required=True, help="Week number to finalize.")
+@click.option(
+    "--season",
+    type=int,
+    default=lambda: datetime.now(timezone.utc).year,
+    show_default="current UTC year",
+    help="Stat season used for points lookup.",
+)
+@click.option("--season-year", type=int, default=None, help="Optional scoring season year.")
+def finalize_week_command(league_id: int, week: int, season: int, season_year: int | None):
+    """Finalize one league week and lock lineup edits for that week.
+
+    This command is designed to run via scheduler (for example Tuesday 4 AM cron).
+    """
+
+    result = run_finalization(
+        league_id=league_id,
+        week=week,
+        season=season,
+        season_year=season_year,
+    )
+
+    click.echo(
+        f"Finalized league={result['league_id']} week={result['week']} "
+        f"matchups={result['matchups_finalized']}"
+    )
 
 
 if __name__ == "__main__":

--- a/backend/routers/scoring.py
+++ b/backend/routers/scoring.py
@@ -5,7 +5,7 @@ import io
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -86,6 +86,20 @@ class ScoringImportApplyRequest(BaseModel):
     season_year: int | None = None
     source_platform: str = "imported"
     replace_existing_for_season: bool = False
+
+
+class PlayerPointsUploadSummary(BaseModel):
+    season: int
+    week: int
+    source: str
+    rows_received: int
+    rows_applied: int
+    rows_invalid: int
+    rows_deleted: int
+    inserted: int
+    updated: int
+    player_id_column: str
+    points_column: str
 
 
 class ScoringRuleProposalCreateRequest(BaseModel):
@@ -201,6 +215,200 @@ def _parse_csv_rules(csv_content: str) -> list[ScoringRuleCreate]:
         return parse_csv_rows_to_rules(csv_content)
     except ScoringImportError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _normalize_header(value: str) -> str:
+    return "".join(ch for ch in str(value or "").lower().strip().replace(" ", "_") if ch.isalnum() or ch == "_")
+
+
+def _coerce_upload_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _resolve_column_name(headers: list[str], preferred: str | None, aliases: list[str]) -> str:
+    normalized = {_normalize_header(name): name for name in headers}
+    if preferred:
+        preferred_key = _normalize_header(preferred)
+        if preferred_key in normalized:
+            return normalized[preferred_key]
+        raise HTTPException(
+            status_code=400,
+            detail=f"Column '{preferred}' not found in upload. Available columns: {headers}",
+        )
+
+    for alias in aliases:
+        alias_key = _normalize_header(alias)
+        if alias_key in normalized:
+            return normalized[alias_key]
+
+    raise HTTPException(
+        status_code=400,
+        detail=f"Could not auto-detect required column. Available columns: {headers}",
+    )
+
+
+def _parse_csv_upload(content: bytes) -> list[dict[str, str]]:
+    text = content.decode("utf-8-sig")
+    reader = csv.DictReader(io.StringIO(text))
+    if not reader.fieldnames:
+        raise HTTPException(status_code=400, detail="CSV upload is missing a header row")
+    return [
+        {
+            (key or "").strip(): _coerce_upload_value(value)
+            for key, value in (row or {}).items()
+        }
+        for row in reader
+    ]
+
+
+def _parse_xlsx_upload(content: bytes) -> list[dict[str, str]]:
+    try:
+        from openpyxl import load_workbook
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="openpyxl is required for xlsx uploads") from exc
+
+    workbook = load_workbook(filename=io.BytesIO(content), read_only=True, data_only=True)
+    try:
+        sheet = workbook.active
+        rows = list(sheet.iter_rows(values_only=True))
+    finally:
+        workbook.close()
+
+    if not rows:
+        raise HTTPException(status_code=400, detail="XLSX upload is empty")
+
+    headers = [_coerce_upload_value(cell) for cell in rows[0]]
+    if not any(headers):
+        raise HTTPException(status_code=400, detail="XLSX upload is missing header columns")
+
+    records: list[dict[str, str]] = []
+    for raw_row in rows[1:]:
+        record: dict[str, str] = {}
+        for idx, header in enumerate(headers):
+            if not header:
+                continue
+            value = raw_row[idx] if idx < len(raw_row) else None
+            record[header] = _coerce_upload_value(value)
+        records.append(record)
+    return records
+
+
+def _extract_points_override_rows(
+    records: list[dict[str, str]],
+    *,
+    player_id_column: str | None,
+    points_column: str | None,
+) -> tuple[list[dict[str, Any]], str, str, int]:
+    if not records:
+        raise HTTPException(status_code=400, detail="Upload contains no data rows")
+
+    headers = sorted({key for row in records for key in row.keys() if key})
+    if not headers:
+        raise HTTPException(status_code=400, detail="Upload contains no readable columns")
+
+    resolved_player_col = _resolve_column_name(
+        headers,
+        player_id_column,
+        aliases=["player_id", "player id", "playerid", "id"],
+    )
+    resolved_points_col = _resolve_column_name(
+        headers,
+        points_column,
+        aliases=["fantasy_points", "fantasy points", "points", "score", "player_points"],
+    )
+
+    invalid_rows = 0
+    parsed: list[dict[str, Any]] = []
+    for row in records:
+        raw_player = _coerce_upload_value(row.get(resolved_player_col))
+        raw_points = _coerce_upload_value(row.get(resolved_points_col))
+        if not raw_player and not raw_points:
+            continue
+        try:
+            player_id = int(float(raw_player))
+            fantasy_points = float(raw_points)
+        except Exception:
+            invalid_rows += 1
+            continue
+        parsed.append({"player_id": player_id, "fantasy_points": fantasy_points})
+
+    if not parsed:
+        raise HTTPException(status_code=400, detail="No valid Player ID/Points rows found in upload")
+
+    return parsed, resolved_player_col, resolved_points_col, invalid_rows
+
+
+def _apply_points_overrides(
+    db: Session,
+    *,
+    season: int,
+    week: int,
+    source: str,
+    rows: list[dict[str, Any]],
+    replace_existing_for_source: bool,
+) -> tuple[int, int, int, int]:
+    # Last value wins when duplicate player IDs appear in the same upload.
+    deduped = {int(item["player_id"]): float(item["fantasy_points"]) for item in rows}
+    player_ids = list(deduped.keys())
+
+    known_ids = {
+        int(row[0])
+        for row in db.query(models.Player.id).filter(models.Player.id.in_(player_ids)).all()
+    }
+    missing = [player_id for player_id in player_ids if player_id not in known_ids]
+    if missing:
+        sample = ", ".join(str(value) for value in missing[:10])
+        raise HTTPException(status_code=400, detail=f"Unknown player_id values in upload: {sample}")
+
+    rows_deleted = 0
+    if replace_existing_for_source:
+        rows_deleted = (
+            db.query(models.PlayerWeeklyStat)
+            .filter(
+                models.PlayerWeeklyStat.season == season,
+                models.PlayerWeeklyStat.week == week,
+                models.PlayerWeeklyStat.source == source,
+            )
+            .delete(synchronize_session=False)
+        )
+
+    existing = {
+        int(stat.player_id): stat
+        for stat in (
+            db.query(models.PlayerWeeklyStat)
+            .filter(
+                models.PlayerWeeklyStat.season == season,
+                models.PlayerWeeklyStat.week == week,
+                models.PlayerWeeklyStat.source == source,
+                models.PlayerWeeklyStat.player_id.in_(player_ids),
+            )
+            .all()
+        )
+    }
+
+    inserted = 0
+    updated = 0
+    for player_id, points in deduped.items():
+        stat = existing.get(player_id)
+        if stat:
+            stat.fantasy_points = points
+            updated += 1
+            continue
+        db.add(
+            models.PlayerWeeklyStat(
+                player_id=player_id,
+                season=season,
+                week=week,
+                fantasy_points=points,
+                stats={"imported_points_override": True},
+                source=source,
+            )
+        )
+        inserted += 1
+
+    return inserted, updated, rows_deleted, len(deduped)
 
 
 @router.get("/rules", response_model=list[ScoringRule])
@@ -438,6 +646,93 @@ def apply_scoring_import(
         db.refresh(row)
 
     return created_rules
+
+
+@router.post("/import/upload-points-override", response_model=PlayerPointsUploadSummary)
+async def upload_points_override(
+    file: UploadFile = File(...),
+    season: int = Query(..., ge=2000, le=2100),
+    week: int = Query(..., ge=1, le=18),
+    source: str = Query(default="manual_override"),
+    replace_existing_for_source: bool = Query(default=True),
+    player_id_column: str | None = Query(default=None),
+    points_column: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(check_is_commissioner),
+):
+    league_id = _league_id_or_400(current_user)
+
+    filename = (file.filename or "").strip()
+    if not filename:
+        raise HTTPException(status_code=400, detail="Uploaded file must include a filename")
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+    lower_name = filename.lower()
+    if lower_name.endswith(".csv"):
+        records = _parse_csv_upload(content)
+    elif lower_name.endswith(".xlsx"):
+        records = _parse_xlsx_upload(content)
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported file type. Use .csv or .xlsx")
+
+    parsed_rows, resolved_player_col, resolved_points_col, invalid_rows = _extract_points_override_rows(
+        records,
+        player_id_column=player_id_column,
+        points_column=points_column,
+    )
+
+    inserted, updated, rows_deleted, rows_applied = _apply_points_overrides(
+        db,
+        season=season,
+        week=week,
+        source=source,
+        rows=parsed_rows,
+        replace_existing_for_source=replace_existing_for_source,
+    )
+
+    _append_change_log(
+        db,
+        league_id=league_id,
+        scoring_rule_id=None,
+        season_year=season,
+        change_type="stats_override_imported",
+        changed_by_user_id=current_user.id,
+        rationale="Player points override imported from uploaded file",
+        previous_value=None,
+        new_value={
+            "filename": filename,
+            "season": season,
+            "week": week,
+            "source": source,
+            "replace_existing_for_source": replace_existing_for_source,
+            "rows_received": len(records),
+            "rows_applied": rows_applied,
+            "rows_invalid": invalid_rows,
+            "rows_deleted": rows_deleted,
+            "inserted": inserted,
+            "updated": updated,
+            "player_id_column": resolved_player_col,
+            "points_column": resolved_points_col,
+        },
+    )
+    db.commit()
+
+    return PlayerPointsUploadSummary(
+        season=season,
+        week=week,
+        source=source,
+        rows_received=len(records),
+        rows_applied=rows_applied,
+        rows_invalid=invalid_rows,
+        rows_deleted=rows_deleted,
+        inserted=inserted,
+        updated=updated,
+        player_id_column=resolved_player_col,
+        points_column=resolved_points_col,
+    )
 
 
 @router.post("/calculate/weeks/{week}/recalculate")

--- a/backend/routers/team.py
+++ b/backend/routers/team.py
@@ -143,6 +143,28 @@ def get_locked_player_ids(db: Session, player_ids: List[int], season: int, week:
     return {row[0] for row in rows}
 
 
+def is_week_finalized(db: Session, league_id: int, week: int) -> bool:
+    matchups = (
+        db.query(models.Matchup)
+        .filter(
+            models.Matchup.league_id == league_id,
+            models.Matchup.week == week,
+        )
+        .all()
+    )
+    if not matchups:
+        return False
+    return all(bool(m.is_completed) and str(m.game_status or "").upper() == "FINAL" for m in matchups)
+
+
+def assert_week_not_finalized(db: Session, league_id: int, week: int) -> None:
+    if is_week_finalized(db, league_id, week):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Week {week} is finalized and lineup edits are locked.",
+        )
+
+
 def get_current_year() -> int:
     return datetime.now(timezone.utc).year
 
@@ -347,6 +369,8 @@ def update_lineup(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
+    assert_week_not_finalized(db, current_user.league_id, payload.week)
+
     picks = db.query(models.DraftPick).filter(
         models.DraftPick.owner_id == current_user.id,
         models.DraftPick.league_id == current_user.league_id,
@@ -421,6 +445,8 @@ def submit_lineup(
     db: Session = Depends(get_db),
     current_user: models.User = Depends(get_current_user),
 ):
+    assert_week_not_finalized(db, current_user.league_id, payload.week)
+
     picks = db.query(models.DraftPick).filter(
         models.DraftPick.owner_id == current_user.id,
         models.DraftPick.league_id == current_user.league_id,

--- a/backend/scripts/finalize_week.py
+++ b/backend/scripts/finalize_week.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+from backend.database import SessionLocal
+from backend.services.week_finalization_service import finalize_league_week
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Finalize one league week: lock matchup scores and refresh standings snapshot."
+    )
+    parser.add_argument("--league-id", type=int, required=True, help="Target league ID")
+    parser.add_argument("--week", type=int, required=True, help="Week number to finalize")
+    parser.add_argument(
+        "--season",
+        type=int,
+        default=datetime.now(timezone.utc).year,
+        help="Stat season used for weekly points lookup",
+    )
+    parser.add_argument(
+        "--season-year",
+        type=int,
+        default=None,
+        help="Optional scoring season year for league-specific rules",
+    )
+    return parser.parse_args()
+
+
+def run_finalization(*, league_id: int, week: int, season: int, season_year: int | None = None) -> dict:
+    db = SessionLocal()
+    try:
+        result = finalize_league_week(
+            db,
+            league_id=league_id,
+            week=week,
+            season=season,
+            season_year=season_year,
+        )
+        db.commit()
+        return result
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def main() -> None:
+    args = parse_args()
+    result = run_finalization(
+        league_id=args.league_id,
+        week=args.week,
+        season=args.season,
+        season_year=args.season_year,
+    )
+
+    print(
+        f"Finalized league={result['league_id']} week={result['week']} "
+        f"matchups={result['matchups_finalized']}"
+    )
+    if result["standings"]:
+        top = result["standings"][0]
+        print(
+            f"Current leader: {top['team_name']} "
+            f"({top['wins']}-{top['losses']}-{top['ties']}, PF={top['points_for']})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/week_finalization_service.py
+++ b/backend/services/week_finalization_service.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from .. import models
+from .scoring_service import recalculate_league_week_scores
+
+
+def _standings_snapshot(db: Session, league_id: int) -> list[dict[str, Any]]:
+    owners = db.query(models.User).filter(models.User.league_id == league_id).all()
+    rows: list[dict[str, Any]] = []
+
+    for owner in owners:
+        wins = losses = ties = 0
+        points_for = points_against = 0.0
+
+        matches = (
+            db.query(models.Matchup)
+            .filter(
+                models.Matchup.league_id == league_id,
+                or_(
+                    models.Matchup.home_team_id == owner.id,
+                    models.Matchup.away_team_id == owner.id,
+                ),
+                models.Matchup.is_completed.is_(True),
+            )
+            .all()
+        )
+
+        for matchup in matches:
+            if matchup.home_team_id == owner.id:
+                score = float(matchup.home_score or 0.0)
+                opp = float(matchup.away_score or 0.0)
+            else:
+                score = float(matchup.away_score or 0.0)
+                opp = float(matchup.home_score or 0.0)
+
+            points_for += score
+            points_against += opp
+            if score > opp:
+                wins += 1
+            elif score < opp:
+                losses += 1
+            else:
+                ties += 1
+
+        rows.append(
+            {
+                "owner_id": int(owner.id),
+                "team_name": owner.team_name or owner.username or f"Team {owner.id}",
+                "wins": wins,
+                "losses": losses,
+                "ties": ties,
+                "points_for": round(points_for, 2),
+                "points_against": round(points_against, 2),
+            }
+        )
+
+    rows.sort(key=lambda row: (-row["wins"], -row["points_for"], row["owner_id"]))
+    return rows
+
+
+def finalize_league_week(
+    db: Session,
+    *,
+    league_id: int,
+    week: int,
+    season: int,
+    season_year: int | None = None,
+) -> dict[str, Any]:
+    recalculated = recalculate_league_week_scores(
+        db,
+        league_id=league_id,
+        week=week,
+        season=season,
+        season_year=season_year,
+    )
+
+    # recalculate_league_week_scores marks each matchup FINAL/completed.
+    db.flush()
+
+    standings = _standings_snapshot(db, league_id)
+
+    return {
+        "league_id": int(league_id),
+        "week": int(week),
+        "season": int(season),
+        "season_year": season_year,
+        "finalized_at": datetime.now(timezone.utc).isoformat(),
+        "matchups_finalized": len(recalculated),
+        "matchup_results": recalculated,
+        "standings": standings,
+    }

--- a/backend/tests/test_scoring_points_override_upload.py
+++ b/backend/tests/test_scoring_points_override_upload.py
@@ -1,0 +1,181 @@
+import io
+import asyncio
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from starlette.datastructures import UploadFile
+
+import models
+from backend.routers.scoring import upload_points_override
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def make_league_and_commissioner(db):
+    league = models.League(name="UploadLeague")
+    db.add(league)
+    db.commit()
+    db.refresh(league)
+
+    commissioner = models.User(
+        username="commissioner",
+        hashed_password="pw",
+        league_id=league.id,
+        is_commissioner=True,
+    )
+    db.add(commissioner)
+    db.commit()
+    db.refresh(commissioner)
+    return league, commissioner
+
+
+def make_player(db, name):
+    player = models.Player(name=name, position="WR")
+    db.add(player)
+    db.commit()
+    db.refresh(player)
+    return player
+
+
+def test_upload_points_override_csv_applies_rows_and_logs_audit(db_session):
+    league, commissioner = make_league_and_commissioner(db_session)
+    p1 = make_player(db_session, "Player One")
+    p2 = make_player(db_session, "Player Two")
+
+    # existing row should be replaced when replace_existing_for_source=True
+    db_session.add(
+        models.PlayerWeeklyStat(
+            player_id=p1.id,
+            season=2026,
+            week=2,
+            fantasy_points=3.0,
+            source="manual_override",
+            stats={"seed": True},
+        )
+    )
+    db_session.commit()
+
+    payload = f"player_id,points\n{p1.id},17.5\n{p2.id},10\n".encode("utf-8")
+    upload = UploadFile(file=io.BytesIO(payload), filename="override.csv")
+
+    summary = asyncio.run(
+        upload_points_override(
+            file=upload,
+            season=2026,
+            week=2,
+            source="manual_override",
+            replace_existing_for_source=True,
+            player_id_column=None,
+            points_column=None,
+            db=db_session,
+            current_user=commissioner,
+        )
+    )
+
+    assert summary.rows_received == 2
+    assert summary.rows_applied == 2
+    assert summary.rows_deleted == 1
+    assert summary.inserted == 2
+    assert summary.updated == 0
+
+    stats = (
+        db_session.query(models.PlayerWeeklyStat)
+        .filter(
+            models.PlayerWeeklyStat.season == 2026,
+            models.PlayerWeeklyStat.week == 2,
+            models.PlayerWeeklyStat.source == "manual_override",
+        )
+        .all()
+    )
+    by_player = {row.player_id: row.fantasy_points for row in stats}
+    assert by_player[p1.id] == 17.5
+    assert by_player[p2.id] == 10.0
+
+    log = (
+        db_session.query(models.ScoringRuleChangeLog)
+        .filter(models.ScoringRuleChangeLog.change_type == "stats_override_imported")
+        .one()
+    )
+    assert log.league_id == league.id
+    assert (log.new_value or {}).get("filename") == "override.csv"
+    assert (log.new_value or {}).get("rows_applied") == 2
+
+
+def test_upload_points_override_xlsx_supports_custom_column_mapping(db_session):
+    _, commissioner = make_league_and_commissioner(db_session)
+    p1 = make_player(db_session, "Spreadsheet Player")
+
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    sheet = workbook.active
+    sheet.append(["Player ID", "Override Pts"])
+    sheet.append([p1.id, 21.25])
+
+    stream = io.BytesIO()
+    workbook.save(stream)
+    stream.seek(0)
+
+    upload = UploadFile(file=stream, filename="override.xlsx")
+    summary = asyncio.run(
+        upload_points_override(
+            file=upload,
+            season=2026,
+            week=3,
+            source="manual_override",
+            replace_existing_for_source=True,
+            player_id_column="Player ID",
+            points_column="Override Pts",
+            db=db_session,
+            current_user=commissioner,
+        )
+    )
+
+    assert summary.rows_applied == 1
+    row = (
+        db_session.query(models.PlayerWeeklyStat)
+        .filter(
+            models.PlayerWeeklyStat.player_id == p1.id,
+            models.PlayerWeeklyStat.season == 2026,
+            models.PlayerWeeklyStat.week == 3,
+            models.PlayerWeeklyStat.source == "manual_override",
+        )
+        .one()
+    )
+    assert row.fantasy_points == 21.25
+
+
+def test_upload_points_override_rejects_unknown_player_id(db_session):
+    _, commissioner = make_league_and_commissioner(db_session)
+    payload = b"player_id,points\n999999,12\n"
+    upload = UploadFile(file=io.BytesIO(payload), filename="override.csv")
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            upload_points_override(
+                file=upload,
+                season=2026,
+                week=4,
+                source="manual_override",
+                replace_existing_for_source=True,
+                player_id_column=None,
+                points_column=None,
+                db=db_session,
+                current_user=commissioner,
+            )
+        )
+
+    assert exc.value.status_code == 400
+    assert "Unknown player_id" in str(exc.value.detail)

--- a/backend/tests/test_week_finalization.py
+++ b/backend/tests/test_week_finalization.py
@@ -1,0 +1,102 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import models
+from backend.routers.team import LineupUpdateRequest, update_lineup
+from backend.services.week_finalization_service import finalize_league_week
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _seed_finalization_league(db):
+    league = models.League(name="FinalizeLeague")
+    db.add(league)
+    db.commit()
+    db.refresh(league)
+
+    home = models.User(username="home", hashed_password="pw", league_id=league.id, team_name="Home Team")
+    away = models.User(username="away", hashed_password="pw", league_id=league.id, team_name="Away Team")
+    db.add_all([home, away])
+    db.commit()
+    db.refresh(home)
+    db.refresh(away)
+
+    qb = models.Player(name="QB One", position="QB", projected_points=20)
+    wr = models.Player(name="WR One", position="WR", projected_points=15)
+    db.add_all([qb, wr])
+    db.commit()
+    db.refresh(qb)
+    db.refresh(wr)
+
+    db.add_all(
+        [
+            models.DraftPick(owner_id=home.id, player_id=qb.id, amount=10, session_id="TEST", year=2026, league_id=league.id, current_status="STARTER"),
+            models.DraftPick(owner_id=away.id, player_id=wr.id, amount=10, session_id="TEST", year=2026, league_id=league.id, current_status="STARTER"),
+            models.PlayerWeeklyStat(player_id=qb.id, season=2026, week=1, fantasy_points=24.0, stats={"fantasy_points": 24.0}, source="test"),
+            models.PlayerWeeklyStat(player_id=wr.id, season=2026, week=1, fantasy_points=10.0, stats={"fantasy_points": 10.0}, source="test"),
+            models.Matchup(league_id=league.id, week=1, home_team_id=home.id, away_team_id=away.id, game_status="IN_PROGRESS", is_completed=False),
+        ]
+    )
+    db.commit()
+
+    return league, home, away
+
+
+def test_finalize_week_sets_matchups_final_and_returns_standings(db_session):
+    league, home, _ = _seed_finalization_league(db_session)
+
+    result = finalize_league_week(
+        db_session,
+        league_id=league.id,
+        week=1,
+        season=2026,
+        season_year=2026,
+    )
+    db_session.commit()
+
+    assert result["matchups_finalized"] == 1
+    assert result["standings"][0]["owner_id"] == home.id
+    assert result["standings"][0]["wins"] == 1
+
+    matchup = db_session.query(models.Matchup).filter(models.Matchup.league_id == league.id, models.Matchup.week == 1).one()
+    assert matchup.is_completed is True
+    assert matchup.game_status == "FINAL"
+    assert matchup.home_score == 24.0
+    assert matchup.away_score == 10.0
+
+
+def test_update_lineup_rejects_when_week_finalized(db_session):
+    league, home, _ = _seed_finalization_league(db_session)
+
+    finalize_league_week(
+        db_session,
+        league_id=league.id,
+        week=1,
+        season=2026,
+        season_year=2026,
+    )
+    db_session.commit()
+
+    payload = LineupUpdateRequest(week=1, starter_player_ids=[])
+    with pytest.raises(HTTPException) as exc:
+        update_lineup(payload=payload, db=db_session, current_user=home)
+
+    assert exc.value.status_code == 400
+    assert "finalized" in str(exc.value.detail).lower()


### PR DESCRIPTION
## Summary
- add commissioner upload endpoint for weekly scoring point overrides (.csv/.xlsx) with column mapping and audit logging
- add week finalization service + script and manage CLI command (inalize-week)
- enforce finalized-week lineup immutability in team lineup update/submit paths
- add targeted backend tests for upload override and week finalization flows

## Validation
- python -m scripts.repo_hygiene_check
- python3.13 -m pytest backend/tests/test_week_finalization.py backend/tests/test_scoring_points_override_upload.py backend/tests/test_scoring_engine_service.py -q
- Result: all passing