### PR TITLE
docs(ops): add cloudflare tunnel systemd runbook

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,7 @@ Refer to the appropriate file for more information.
 - [Architecture](ARCHITECTURE.md)
 - [Cloudflare Tunnel Setup](CLOUDFLARE_TUNNEL_SETUP.md)
 - [Cloudflare Tunnel Monitoring](cloudflare-tunnel-monitoring.md)
+- [Cloudflare Tunnel systemd Runbook](cloudflare-tunnel-systemd.md)
 - [Cross Module Edge Case Test Matrix](CROSS_MODULE_EDGE_CASE_TEST_MATRIX.md)
 - [Data Validation Strategy](DATA_VALIDATION_STRATEGY.md)
 - [Db Migration Phase1](DB_MIGRATION_PHASE1.md)

--- a/docs/cloudflare-tunnel-systemd.md
+++ b/docs/cloudflare-tunnel-systemd.md
@@ -1,0 +1,133 @@
+# Cloudflare Tunnel systemd Runbook (Raspberry Pi)
+
+Date: 2026-03-10
+Related Issue: #208
+
+## Goal
+Provide a reproducible systemd setup so `cloudflared` starts on boot, restarts on failures, and is observable with `journalctl`.
+
+## Source of truth files in repo
+- Service template: `deploy/systemd/cloudflared.service.example`
+- Watchdog service template: `deploy/systemd/cloudflared-watchdog.service.example`
+- Watchdog timer template: `deploy/systemd/cloudflared-watchdog.timer.example`
+- One-command installer: `deploy/systemd/install_cloudflared_monitoring.sh`
+- Tunnel config template: `deploy/cloudflared/config.ppl-insight-hub-prod1.example.yml`
+
+## Directory structure on Pi
+- Tunnel config: `/etc/cloudflared/config.yml`
+- Tunnel credentials JSON: `/etc/cloudflared/<tunnel-id>.json`
+- Unit files: `/etc/systemd/system/cloudflared*.service`, `/etc/systemd/system/cloudflared-watchdog.timer`
+
+## 1. Prerequisites
+```bash
+cloudflared --version
+sudo ls -la /etc/cloudflared
+sudo test -f /etc/cloudflared/config.yml && echo "config present"
+```
+
+Expected:
+- `cloudflared` binary installed
+- `config.yml` present
+- tunnel credentials JSON present
+
+## 2. Install/Update systemd units
+Option A: one command (recommended)
+```bash
+cd /opt/fantasy-football-pi
+sudo bash deploy/systemd/install_cloudflared_monitoring.sh
+```
+
+Option B: manual copy
+```bash
+cd /opt/fantasy-football-pi
+sudo cp deploy/systemd/cloudflared.service.example /etc/systemd/system/cloudflared.service
+sudo cp deploy/systemd/cloudflared-watchdog.service.example /etc/systemd/system/cloudflared-watchdog.service
+sudo cp deploy/systemd/cloudflared-watchdog.timer.example /etc/systemd/system/cloudflared-watchdog.timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now cloudflared.service
+sudo systemctl enable --now cloudflared-watchdog.timer
+```
+
+## 3. Validate service health
+```bash
+sudo systemctl status cloudflared --no-pager
+sudo systemctl status cloudflared-watchdog.timer --no-pager
+sudo journalctl -u cloudflared -n 200 --no-pager
+cloudflared tunnel info ppl-insight-hub-prod1
+```
+
+## 4. Reboot validation
+```bash
+sudo reboot
+```
+After reboot:
+```bash
+sudo systemctl is-enabled cloudflared
+sudo systemctl is-active cloudflared
+sudo systemctl is-enabled cloudflared-watchdog.timer
+sudo systemctl is-active cloudflared-watchdog.timer
+```
+
+Expected:
+- both units are `enabled`
+- both units are `active`
+
+## 5. Failure and reconnect behavior checks
+Simulate service failure:
+```bash
+sudo systemctl stop cloudflared
+sleep 3
+sudo systemctl status cloudflared --no-pager
+```
+
+Simulate network disruption and observe reconnect:
+```bash
+sudo journalctl -u cloudflared --since "-10m" --no-pager
+```
+
+Public endpoint check:
+```bash
+curl -i https://pplinsighthub.com/health
+```
+
+## Troubleshooting
+### Service fails to start
+Checks:
+```bash
+sudo systemctl status cloudflared --no-pager
+sudo journalctl -u cloudflared -n 200 --no-pager
+```
+Common fixes:
+- wrong `ExecStart` binary path in unit
+- invalid `/etc/cloudflared/config.yml`
+- missing/incorrect tunnel credentials JSON
+
+### Tunnel starts but traffic does not route
+Checks:
+```bash
+cloudflared tunnel list
+cloudflared tunnel info ppl-insight-hub-prod1
+sudo cat /etc/cloudflared/config.yml
+```
+Common fixes:
+- `tunnel:` ID mismatch between config and credentials
+- incorrect ingress `service` target
+- DNS route not pointing to tunnel UUID endpoint
+
+### Watchdog not triggering restart
+Checks:
+```bash
+sudo systemctl status cloudflared-watchdog.timer --no-pager
+sudo systemctl list-timers --all | grep cloudflared-watchdog
+```
+Common fixes:
+- timer not enabled
+- watchdog service file not copied to `/etc/systemd/system`
+- `daemon-reload` not run after unit updates
+
+## Acceptance mapping (#208)
+- Boot persistence: yes (`enable --now cloudflared.service`)
+- Auto-restart on failure: yes (`Restart=on-failure`)
+- Logs available: yes (`journalctl -u cloudflared`)
+- No manual upkeep required: yes (service + watchdog timer)
+- Reproducible documentation: yes (this runbook)


### PR DESCRIPTION
## Summary
- add dedicated systemd-focused tunnel runbook: docs/cloudflare-tunnel-systemd.md
- document prerequisites, unit install/update flows, reboot validation, reconnect checks, and troubleshooting
- include acceptance mapping for issue #208
- add docs index entry for discoverability

## Validation
- python3.13.exe -m scripts.repo_hygiene_check (pass)

Closes #208