### PR TITLE
chore(ui): add stage2 table primitive guardrail

### DIFF
--- a/docs/FRONTEND_UI_STANDARDS.md
+++ b/docs/FRONTEND_UI_STANDARDS.md
@@ -89,6 +89,9 @@
 - Every styling PR that touches routes updates this matrix.
 - Theme-toggle smoke checks are required for touched routes (light and dark).
 - Responsive audit remains active in CI.
+- Repository hygiene now includes a Stage 2 guardrail check:
+  - Route pages cannot introduce raw `<table>` markup unless they import
+    `@components/table/TablePrimitives`.
 
 ### 9) Layering and Spacing Guardrails
 

--- a/scripts/repo_hygiene_check.py
+++ b/scripts/repo_hygiene_check.py
@@ -118,11 +118,37 @@ def check_frontend_component_naming() -> list[str]:
     return issues
 
 
+def check_frontend_ui_guardrails() -> list[str]:
+    """Enforce baseline frontend standardization guardrails.
+
+    Current guardrail scope (Stage 2):
+    - Route pages should not introduce raw `<table>` markup unless they also
+      consume shared table primitives from `@components/table/TablePrimitives`.
+    """
+    issues: list[str] = []
+    pages_dir = FRONTEND_SRC / "pages"
+    if not pages_dir.exists():
+        return issues
+
+    for file in list(pages_dir.rglob("*.jsx")) + list(pages_dir.rglob("*.tsx")):
+        text = _read_text(file)
+        has_raw_table = "<table" in text
+        uses_primitives = "@components/table/TablePrimitives" in text
+        if has_raw_table and not uses_primitives:
+            issues.append(
+                "route page contains raw <table> without TablePrimitives import: "
+                f"{file.relative_to(ROOT).as_posix()}"
+            )
+
+    return issues
+
+
 def main() -> int:
     issues: list[str] = []
     issues.extend(check_docs_index())
     issues.extend(check_case_collisions())
     issues.extend(check_frontend_component_naming())
+    issues.extend(check_frontend_ui_guardrails())
 
     if issues:
         print("repo hygiene check failed:")


### PR DESCRIPTION
## Summary
- implement Stage 2 UI drift guardrail in scripts/repo_hygiene_check.py
- new guardrail enforces route pages do not introduce raw <table> markup unless @components/table/TablePrimitives is imported
- document guardrail in docs/FRONTEND_UI_STANDARDS.md

## Validation
- python3.13.exe -m scripts.repo_hygiene_check (pass)

Closes #204