### PR TITLE
ci: add observability dashboard and reporting hooks (#199)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    outputs:
+      duration_seconds: ${{ steps.timing_end.outputs.duration_seconds }}
+      failure_category: ${{ steps.result_category.outputs.category }}
     strategy:
       matrix:
         python-version: [3.11]
@@ -33,6 +36,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Record backend job start time
+        id: timing_start
+        run: |
+          echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -98,14 +106,45 @@ jobs:
           name: backend-coverage
           path: backend-coverage.xml
 
+      - name: Categorize backend failure
+        if: always()
+        id: result_category
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "category=none" >> "$GITHUB_OUTPUT"
+          else
+            echo "category=backend" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record backend job duration
+        if: always()
+        id: timing_end
+        env:
+          START_EPOCH: ${{ steps.timing_start.outputs.epoch }}
+        run: |
+          NOW_EPOCH=$(date +%s)
+          if [ -z "$START_EPOCH" ]; then
+            START_EPOCH=$NOW_EPOCH
+          fi
+          DURATION=$((NOW_EPOCH - START_EPOCH))
+          echo "duration_seconds=$DURATION" >> "$GITHUB_OUTPUT"
+
   frontend-test:
     runs-on: ubuntu-latest
+    outputs:
+      duration_seconds: ${{ steps.timing_end.outputs.duration_seconds }}
+      failure_category: ${{ steps.result_category.outputs.category }}
     strategy:
       matrix:
         node-version: [20]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Record frontend job start time
+        id: timing_start
+        run: |
+          echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -142,12 +181,43 @@ jobs:
           name: frontend-coverage
           path: frontend/coverage
 
+      - name: Categorize frontend failure
+        if: always()
+        id: result_category
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "category=none" >> "$GITHUB_OUTPUT"
+          else
+            echo "category=frontend" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record frontend job duration
+        if: always()
+        id: timing_end
+        env:
+          START_EPOCH: ${{ steps.timing_start.outputs.epoch }}
+        run: |
+          NOW_EPOCH=$(date +%s)
+          if [ -z "$START_EPOCH" ]; then
+            START_EPOCH=$NOW_EPOCH
+          fi
+          DURATION=$((NOW_EPOCH - START_EPOCH))
+          echo "duration_seconds=$DURATION" >> "$GITHUB_OUTPUT"
+
   e2e:
     runs-on: ubuntu-latest
     needs: frontend-test
+    outputs:
+      duration_seconds: ${{ steps.timing_end.outputs.duration_seconds }}
+      failure_category: ${{ steps.result_category.outputs.category }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Record API/E2E job start time
+        id: timing_start
+        run: |
+          echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -192,3 +262,129 @@ jobs:
           name: cypress-videos
           if-no-files-found: ignore
           path: frontend/cypress/videos
+
+      - name: Categorize API/E2E failure
+        if: always()
+        id: result_category
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "category=none" >> "$GITHUB_OUTPUT"
+          else
+            echo "category=api" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record API/E2E job duration
+        if: always()
+        id: timing_end
+        env:
+          START_EPOCH: ${{ steps.timing_start.outputs.epoch }}
+        run: |
+          NOW_EPOCH=$(date +%s)
+          if [ -z "$START_EPOCH" ]; then
+            START_EPOCH=$NOW_EPOCH
+          fi
+          DURATION=$((NOW_EPOCH - START_EPOCH))
+          echo "duration_seconds=$DURATION" >> "$GITHUB_OUTPUT"
+
+  observability:
+    name: CI Observability Report
+    runs-on: ubuntu-latest
+    needs: [test, frontend-test, e2e]
+    if: always()
+    steps:
+      - name: Build CI dashboard summary
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BACKEND_RESULT: ${{ needs.test.result }}
+          FRONTEND_RESULT: ${{ needs['frontend-test'].result }}
+          API_RESULT: ${{ needs.e2e.result }}
+          BACKEND_DURATION: ${{ needs.test.outputs.duration_seconds }}
+          FRONTEND_DURATION: ${{ needs['frontend-test'].outputs.duration_seconds }}
+          API_DURATION: ${{ needs.e2e.outputs.duration_seconds }}
+          BACKEND_CATEGORY: ${{ needs.test.outputs.failure_category }}
+          FRONTEND_CATEGORY: ${{ needs['frontend-test'].outputs.failure_category }}
+          API_CATEGORY: ${{ needs.e2e.outputs.failure_category }}
+        run: |
+          status_icon() {
+            case "$1" in
+              success) echo "SUCCESS" ;;
+              failure) echo "FAILURE" ;;
+              cancelled) echo "CANCELLED" ;;
+              skipped) echo "SKIPPED" ;;
+              *) echo "UNKNOWN" ;;
+            esac
+          }
+
+          BACKEND_DURATION=${BACKEND_DURATION:-0}
+          FRONTEND_DURATION=${FRONTEND_DURATION:-0}
+          API_DURATION=${API_DURATION:-0}
+          TOTAL_DURATION=$((BACKEND_DURATION + FRONTEND_DURATION + API_DURATION))
+
+          FAILED_CATEGORIES=""
+          [ "$BACKEND_CATEGORY" != "none" ] && FAILED_CATEGORIES="$FAILED_CATEGORIES backend"
+          [ "$FRONTEND_CATEGORY" != "none" ] && FAILED_CATEGORIES="$FAILED_CATEGORIES frontend"
+          [ "$API_CATEGORY" != "none" ] && FAILED_CATEGORIES="$FAILED_CATEGORIES api"
+
+          if [ -z "$FAILED_CATEGORIES" ]; then
+            FAILED_CATEGORIES="none"
+          fi
+
+          {
+            echo "## CI/CD Observability Dashboard"
+            echo ""
+            echo "Pipeline: [$GITHUB_WORKFLOW run #$GITHUB_RUN_NUMBER]($RUN_URL)"
+            echo ""
+            echo "| Area | Status | Duration (s) | Failure Category |"
+            echo "|---|---|---:|---|"
+            echo "| Backend | $(status_icon "$BACKEND_RESULT") | $BACKEND_DURATION | ${BACKEND_CATEGORY:-none} |"
+            echo "| Frontend | $(status_icon "$FRONTEND_RESULT") | $FRONTEND_DURATION | ${FRONTEND_CATEGORY:-none} |"
+            echo "| API / E2E | $(status_icon "$API_RESULT") | $API_DURATION | ${API_CATEGORY:-none} |"
+            echo "| Deployment | NOT RUN | 0 | deployment_not_in_scope |"
+            echo ""
+            echo "- Total build time (tracked jobs): ${TOTAL_DURATION}s"
+            echo "- Failed categories: $FAILED_CATEGORIES"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify Slack on CI failure
+        if: needs.test.result != 'success' || needs['frontend-test'].result != 'success' || needs.e2e.result != 'success'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BACKEND_RESULT: ${{ needs.test.result }}
+          FRONTEND_RESULT: ${{ needs['frontend-test'].result }}
+          API_RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not configured; skipping Slack notification."
+            exit 0
+          fi
+
+          payload=$(cat <<EOF
+          {
+            "text": "CI failed for ${{ github.repository }} on ${{ github.ref_name }}. Backend=$BACKEND_RESULT, Frontend=$FRONTEND_RESULT, API/E2E=$API_RESULT. Run: $RUN_URL"
+          }
+          EOF
+          )
+          curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+
+      - name: Notify Teams on CI failure
+        if: needs.test.result != 'success' || needs['frontend-test'].result != 'success' || needs.e2e.result != 'success'
+        env:
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BACKEND_RESULT: ${{ needs.test.result }}
+          FRONTEND_RESULT: ${{ needs['frontend-test'].result }}
+          API_RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [ -z "$TEAMS_WEBHOOK_URL" ]; then
+            echo "TEAMS_WEBHOOK_URL not configured; skipping Teams notification."
+            exit 0
+          fi
+
+          payload=$(cat <<EOF
+          {
+            "text": "CI failed for ${{ github.repository }} on ${{ github.ref_name }}. Backend=$BACKEND_RESULT, Frontend=$FRONTEND_RESULT, API/E2E=$API_RESULT. Run: $RUN_URL"
+          }
+          EOF
+          )
+          curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$TEAMS_WEBHOOK_URL"

--- a/docs/CI_CD_OBSERVABILITY.md
+++ b/docs/CI_CD_OBSERVABILITY.md
@@ -1,0 +1,42 @@
+# CI/CD Observability and Reporting
+
+This project ships a built-in CI observability report in `.github/workflows/ci.yml`.
+
+## What is reported
+
+Each CI run publishes a dashboard to the GitHub Actions Step Summary with:
+
+- Per-area status:
+  - `Backend` (Python tests and coverage)
+  - `Frontend` (lint, responsive audit, unit coverage)
+  - `API / E2E` (Cypress workflow)
+  - `Deployment` (marked as `deployment_not_in_scope` for this workflow)
+- Per-area build time (seconds)
+- Total tracked build time (sum of backend, frontend, API/E2E)
+- Failure categories (`backend`, `frontend`, `api`, or `none`)
+
+## Where to view the dashboard
+
+1. Open any CI run in GitHub Actions.
+2. Open the `CI Observability Report` job.
+3. Read the `Build CI dashboard summary` step summary.
+
+## Optional failure notifications
+
+The workflow sends failure alerts only when webhook secrets are present.
+
+Supported secrets:
+
+- `SLACK_WEBHOOK_URL`
+- `TEAMS_WEBHOOK_URL`
+
+Notification behavior:
+
+- Alerts trigger when any of `test`, `frontend-test`, or `e2e` is not `success`.
+- Payload includes branch, area results, and direct run URL.
+- If a secret is missing, that notifier is skipped automatically.
+
+## Notes
+
+- `Deployment` is intentionally categorized as not in scope for this CI pipeline.
+- If deployment validation is added later, update the observability table and category mapping in `.github/workflows/ci.yml`.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -35,6 +35,7 @@ Refer to the appropriate file for more information.
 - [Testing Session Summary](TESTING_SESSION_SUMMARY.md)
 - [Ui Reference](UI_REFERENCE.md)
 - [Cli Checkin Lessons Learned](CLI_CHECKIN_LESSONS_LEARNED.md)
+- [Ci Cd Observability](CI_CD_OBSERVABILITY.md)
 - [Uat Master Instructions](uat/UAT_MASTER_DOCUMENT_INSTRUCTIONS.md)
 - [Uat Deck Image Coverage](uat/UAT_DECK_IMAGE_COVERAGE.md)
 - [Ux Insights Spec](ux-insights-spec.md)


### PR DESCRIPTION
## Summary\n- add per-job timing and failure-category outputs in CI jobs\n- add a dedicated CI Observability Report job that writes a GitHub Actions dashboard summary\n- add optional Slack and Teams failure notifications gated by webhook secrets\n- document setup and usage in docs/CI_CD_OBSERVABILITY.md and docs index\n\n## Validation\n- python -m scripts.repo_hygiene_check\n\nCloses #199