### PR TITLE
ci: add API integration contract and smoke pipeline (#196)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,125 @@ jobs:
           DURATION=$((NOW_EPOCH - START_EPOCH))
           echo "duration_seconds=$DURATION" >> "$GITHUB_OUTPUT"
 
+  api-integration:
+    runs-on: ubuntu-latest
+    needs: test
+    outputs:
+      duration_seconds: ${{ steps.timing_end.outputs.duration_seconds }}
+      failure_category: ${{ steps.result_category.outputs.category }}
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: fantasy_pi
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:password@localhost:5432/fantasy_pi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Record API integration job start time
+        id: timing_start
+        run: |
+          echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Seed database
+        run: |
+          python -m backend.manage seed
+        env:
+          PYTHONPATH: .
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+
+      - name: Run API integration and contract tests
+        run: |
+          python -m pytest backend/tests/test_api_integration_pipeline.py -q
+        env:
+          PYTHONPATH: .
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+
+      - name: Run API smoke checks against local service
+        run: |
+          set -euo pipefail
+          python -m uvicorn backend.main:app --host 127.0.0.1 --port 8012 > api-smoke.log 2>&1 &
+          UVICORN_PID=$!
+
+          cleanup() {
+            kill "$UVICORN_PID" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          for i in {1..25}; do
+            if curl -fsS http://127.0.0.1:8012/health > /tmp/health.json; then
+              break
+            fi
+            sleep 1
+          done
+
+          curl -fsS http://127.0.0.1:8012/openapi.json > /tmp/openapi.json
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          health = json.loads(Path('/tmp/health.json').read_text(encoding='utf-8'))
+          openapi = json.loads(Path('/tmp/openapi.json').read_text(encoding='utf-8'))
+
+          assert health.get('status') in {'ok', 'degraded'}, health
+          assert '/auth/token' in openapi.get('paths', {}), 'Missing /auth/token in OpenAPI paths'
+          assert '/health' in openapi.get('paths', {}), 'Missing /health in OpenAPI paths'
+          print('API smoke contract checks passed.')
+          PY
+
+      - name: Upload API smoke logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-smoke-logs
+          if-no-files-found: ignore
+          path: api-smoke.log
+
+      - name: Categorize API integration failure
+        if: always()
+        id: result_category
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "category=none" >> "$GITHUB_OUTPUT"
+          else
+            echo "category=api_contract" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record API integration job duration
+        if: always()
+        id: timing_end
+        env:
+          START_EPOCH: ${{ steps.timing_start.outputs.epoch }}
+        run: |
+          NOW_EPOCH=$(date +%s)
+          if [ -z "$START_EPOCH" ]; then
+            START_EPOCH=$NOW_EPOCH
+          fi
+          DURATION=$((NOW_EPOCH - START_EPOCH))
+          echo "duration_seconds=$DURATION" >> "$GITHUB_OUTPUT"
+
   frontend-test:
     runs-on: ubuntu-latest
     outputs:
@@ -289,7 +408,7 @@ jobs:
   observability:
     name: CI Observability Report
     runs-on: ubuntu-latest
-    needs: [test, frontend-test, e2e]
+    needs: [test, api-integration, frontend-test, e2e]
     if: always()
     steps:
       - name: Build CI dashboard summary
@@ -297,11 +416,14 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BACKEND_RESULT: ${{ needs.test.result }}
           FRONTEND_RESULT: ${{ needs['frontend-test'].result }}
+          API_CONTRACT_RESULT: ${{ needs['api-integration'].result }}
           API_RESULT: ${{ needs.e2e.result }}
           BACKEND_DURATION: ${{ needs.test.outputs.duration_seconds }}
+          API_CONTRACT_DURATION: ${{ needs['api-integration'].outputs.duration_seconds }}
           FRONTEND_DURATION: ${{ needs['frontend-test'].outputs.duration_seconds }}
           API_DURATION: ${{ needs.e2e.outputs.duration_seconds }}
           BACKEND_CATEGORY: ${{ needs.test.outputs.failure_category }}
+          API_CONTRACT_CATEGORY: ${{ needs['api-integration'].outputs.failure_category }}
           FRONTEND_CATEGORY: ${{ needs['frontend-test'].outputs.failure_category }}
           API_CATEGORY: ${{ needs.e2e.outputs.failure_category }}
         run: |
@@ -316,12 +438,14 @@ jobs:
           }
 
           BACKEND_DURATION=${BACKEND_DURATION:-0}
+          API_CONTRACT_DURATION=${API_CONTRACT_DURATION:-0}
           FRONTEND_DURATION=${FRONTEND_DURATION:-0}
           API_DURATION=${API_DURATION:-0}
-          TOTAL_DURATION=$((BACKEND_DURATION + FRONTEND_DURATION + API_DURATION))
+          TOTAL_DURATION=$((BACKEND_DURATION + API_CONTRACT_DURATION + FRONTEND_DURATION + API_DURATION))
 
           FAILED_CATEGORIES=""
           [ "$BACKEND_CATEGORY" != "none" ] && FAILED_CATEGORIES="$FAILED_CATEGORIES backend"
+          [ "$API_CONTRACT_CATEGORY" != "none" ] && FAILED_CATEGORIES="$FAILED_CATEGORIES api_contract"
           [ "$FRONTEND_CATEGORY" != "none" ] && FAILED_CATEGORIES="$FAILED_CATEGORIES frontend"
           [ "$API_CATEGORY" != "none" ] && FAILED_CATEGORIES="$FAILED_CATEGORIES api"
 
@@ -337,6 +461,7 @@ jobs:
             echo "| Area | Status | Duration (s) | Failure Category |"
             echo "|---|---|---:|---|"
             echo "| Backend | $(status_icon "$BACKEND_RESULT") | $BACKEND_DURATION | ${BACKEND_CATEGORY:-none} |"
+            echo "| API Contract & Smoke | $(status_icon "$API_CONTRACT_RESULT") | $API_CONTRACT_DURATION | ${API_CONTRACT_CATEGORY:-none} |"
             echo "| Frontend | $(status_icon "$FRONTEND_RESULT") | $FRONTEND_DURATION | ${FRONTEND_CATEGORY:-none} |"
             echo "| API / E2E | $(status_icon "$API_RESULT") | $API_DURATION | ${API_CATEGORY:-none} |"
             echo "| Deployment | NOT RUN | 0 | deployment_not_in_scope |"
@@ -346,11 +471,12 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Notify Slack on CI failure
-        if: needs.test.result != 'success' || needs['frontend-test'].result != 'success' || needs.e2e.result != 'success'
+        if: needs.test.result != 'success' || needs['api-integration'].result != 'success' || needs['frontend-test'].result != 'success' || needs.e2e.result != 'success'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BACKEND_RESULT: ${{ needs.test.result }}
+          API_CONTRACT_RESULT: ${{ needs['api-integration'].result }}
           FRONTEND_RESULT: ${{ needs['frontend-test'].result }}
           API_RESULT: ${{ needs.e2e.result }}
         run: |
@@ -361,18 +487,19 @@ jobs:
 
           payload=$(cat <<EOF
           {
-            "text": "CI failed for ${{ github.repository }} on ${{ github.ref_name }}. Backend=$BACKEND_RESULT, Frontend=$FRONTEND_RESULT, API/E2E=$API_RESULT. Run: $RUN_URL"
+            "text": "CI failed for ${{ github.repository }} on ${{ github.ref_name }}. Backend=$BACKEND_RESULT, API Contract=$API_CONTRACT_RESULT, Frontend=$FRONTEND_RESULT, API/E2E=$API_RESULT. Run: $RUN_URL"
           }
           EOF
           )
           curl -sS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
 
       - name: Notify Teams on CI failure
-        if: needs.test.result != 'success' || needs['frontend-test'].result != 'success' || needs.e2e.result != 'success'
+        if: needs.test.result != 'success' || needs['api-integration'].result != 'success' || needs['frontend-test'].result != 'success' || needs.e2e.result != 'success'
         env:
           TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BACKEND_RESULT: ${{ needs.test.result }}
+          API_CONTRACT_RESULT: ${{ needs['api-integration'].result }}
           FRONTEND_RESULT: ${{ needs['frontend-test'].result }}
           API_RESULT: ${{ needs.e2e.result }}
         run: |
@@ -383,7 +510,7 @@ jobs:
 
           payload=$(cat <<EOF
           {
-            "text": "CI failed for ${{ github.repository }} on ${{ github.ref_name }}. Backend=$BACKEND_RESULT, Frontend=$FRONTEND_RESULT, API/E2E=$API_RESULT. Run: $RUN_URL"
+            "text": "CI failed for ${{ github.repository }} on ${{ github.ref_name }}. Backend=$BACKEND_RESULT, API Contract=$API_CONTRACT_RESULT, Frontend=$FRONTEND_RESULT, API/E2E=$API_RESULT. Run: $RUN_URL"
           }
           EOF
           )

--- a/backend/tests/test_api_integration_pipeline.py
+++ b/backend/tests/test_api_integration_pipeline.py
@@ -1,0 +1,96 @@
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import models
+from backend.core import security
+from backend.database import get_db
+from backend.main import app
+
+
+@pytest.fixture
+def api_db():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    models.Base.metadata.create_all(bind=engine)
+
+    db = testing_session_local()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies(api_db):
+    def override_get_db():
+        try:
+            yield api_db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_health_contract_shape(client):
+    response = client.get("/health")
+    assert response.status_code in {200, 503}
+
+    payload = response.json()
+    assert set(payload.keys()) == {"status", "service", "database"}
+    assert payload["status"] in {"ok", "degraded"}
+    assert payload["service"] == "fantasy-football-backend"
+    assert payload["database"] in {"ok", "error"}
+
+
+def test_auth_token_contract_shape(client, api_db, monkeypatch):
+    monkeypatch.setattr(
+        security,
+        "verify_password",
+        lambda plain_password, hashed_password: plain_password == "secret" and hashed_password == "test-hash",
+    )
+
+    user = models.User(
+        username="contract-user",
+        email="contract-user@test.com",
+        hashed_password="test-hash",
+        league_id=1,
+    )
+    api_db.add(user)
+    api_db.commit()
+
+    response = client.post(
+        "/auth/token",
+        data={"username": "contract-user", "password": "secret"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert "access_token" in payload
+    assert payload["access_token"]
+    assert payload["token_type"] == "bearer"
+    assert isinstance(payload.get("owner_id"), int)
+
+
+def test_openapi_contract_contains_required_paths(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    payload = response.json()
+    paths = payload.get("paths", {})
+    assert "/auth/token" in paths
+    assert "/health" in paths

--- a/docs/API_INTEGRATION_PIPELINE.md
+++ b/docs/API_INTEGRATION_PIPELINE.md
@@ -1,0 +1,46 @@
+# API Integration Test Pipeline
+
+This runbook documents the CI API integration pipeline introduced for issue #196.
+
+## Scope
+
+The CI workflow now includes a dedicated `api-integration` job in `.github/workflows/ci.yml`.
+
+It runs on every pull request to `main` and includes:
+
+- integration tests with database-backed app behavior
+- API contract tests for response shape and required OpenAPI paths
+- smoke tests against a locally started backend service
+- API smoke log artifact upload (`api-smoke-logs`)
+
+## Tests executed
+
+`backend/tests/test_api_integration_pipeline.py` validates:
+
+- `GET /health` contract shape (`status`, `service`, `database`)
+- `POST /auth/token` contract shape (`access_token`, `token_type`, `owner_id`)
+- `GET /openapi.json` includes required paths (`/auth/token`, `/health`)
+
+## CI compatibility reporting
+
+`CI Observability Report` now includes a dedicated row:
+
+- `API Contract & Smoke`
+
+This row is used to quickly diagnose API compatibility failures separate from frontend E2E failures.
+
+## Deployment smoke step behavior
+
+The API integration job starts a local backend service (`uvicorn`) and verifies:
+
+- `/health` endpoint responds
+- `/openapi.json` can be fetched
+- contract-required paths exist in OpenAPI payload
+
+## Failure categorization
+
+When this job fails, the observability report marks failure category as:
+
+- `api_contract`
+
+This category is also included in Slack/Teams failure notifications (when webhooks are configured).

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,6 +4,7 @@ This folder contains high-level documentation for the Fantasy Football Pi projec
 Refer to the appropriate file for more information.
 
 - [Api Page Matrix](API_PAGE_MATRIX.md)
+- [Api Integration Pipeline](API_INTEGRATION_PIPELINE.md)
 - [Architecture](ARCHITECTURE.md)
 - [Cloudflare Tunnel Setup](CLOUDFLARE_TUNNEL_SETUP.md)
 - [Cloudflare Tunnel CLI Runbook](cloudflare-tunnel-cli.md)


### PR DESCRIPTION
## Summary\n- add dedicated pi-integration CI job that runs on every PR\n- add backend API contract/integration tests (ackend/tests/test_api_integration_pipeline.py)\n- add local-service smoke test step (/health, /openapi.json) with log artifact upload\n- expose API compatibility status in CI Observability Report and failure notifications\n- document workflow in docs/API_INTEGRATION_PIPELINE.md\n\n## Validation\n- python -m scripts.repo_hygiene_check\n- python3.13.exe -m pytest backend/tests/test_api_integration_pipeline.py -q\n\nCloses #196