### PR TITLE
fix: commissioner lineup rules not propagating to owner pages (#166)

### DIFF
--- a/backend/routers/league.py
+++ b/backend/routers/league.py
@@ -115,6 +115,35 @@ class LedgerStatementSchema(BaseModel):
     entries: List[LedgerEntrySchema]
 
 
+# --- Helper function to format validation errors as readable string ---
+def format_validation_errors(errors: Dict[str, Any]) -> str:
+    """
+    Convert validation error dict to a readable error message.
+    Handles both pydantic format and manual validation format.
+    """
+    messages = []
+    
+    # Handle pydantic validation errors (detail: list of error dicts)
+    if "detail" in errors and isinstance(errors["detail"], list):
+        for err in errors["detail"]:
+            if isinstance(err, dict):
+                field = err.get("loc", ["unknown"])[-1]
+                msg = err.get("msg", "Invalid value")
+                messages.append(f"{field}: {msg}")
+    # Handle manual validation errors (dict with lists of error strings)
+    else:
+        for field, field_errors in errors.items():
+            if isinstance(field_errors, list):
+                # Join multiple errors for same field with "; "
+                error_text = "; ".join(field_errors)
+                messages.append(f"{field}: {error_text}")
+            else:
+                messages.append(f"{field}: {field_errors}")
+    
+    # Return joined message or generic fallback
+    return " | ".join(messages) if messages else "Validation failed"
+
+
 def validate_lineup_rules(config: LeagueConfigFull) -> None:
     slots = config.starting_slots or {}
 
@@ -734,11 +763,13 @@ def update_league_settings(
 
     boundary_report = validate_league_settings_boundary(settings_payload)
     if not boundary_report.valid:
-        raise HTTPException(status_code=400, detail=boundary_report.errors)
+        error_msg = format_validation_errors(boundary_report.errors)
+        raise HTTPException(status_code=400, detail=error_msg)
 
     dynamic_report = validate_league_settings_dynamic_rules(settings_payload)
     if not dynamic_report.valid:
-        raise HTTPException(status_code=400, detail=dynamic_report.errors)
+        error_msg = format_validation_errors(dynamic_report.errors)
+        raise HTTPException(status_code=400, detail=error_msg)
 
     validate_lineup_rules(config)
 

--- a/backend/services/validation_service.py
+++ b/backend/services/validation_service.py
@@ -195,6 +195,7 @@ def _manual_dynamic_league_settings_validation(payload: dict[str, Any]) -> Valid
         errors.setdefault("starting_slots", []).append("must include at least one slot")
     else:
         total_slots = 0
+        counted_starter_slots = 0
         for key, value in starting_slots.items():
             if not isinstance(key, str) or not key.strip():
                 errors.setdefault("starting_slots", []).append("contains an invalid slot key")
@@ -202,10 +203,24 @@ def _manual_dynamic_league_settings_validation(payload: dict[str, Any]) -> Valid
             if not isinstance(value, int) or value < 0:
                 errors.setdefault(f"starting_slots.{key}", []).append("must be a non-negative integer")
                 continue
-            total_slots += value
 
-        if isinstance(roster_size, int) and total_slots > roster_size:
-            errors.setdefault("starting_slots", []).append("sum of starting slots cannot exceed roster_size")
+            # Only count concrete starter slots (QB/RB/WR/...) toward the lineup sum.
+            # Metadata keys like MAX_QB, ACTIVE_ROSTER_SIZE, toggles, etc. should not
+            # be included in this check.
+            normalized_key = key.strip().upper()
+            if "_" not in normalized_key:
+                total_slots += value
+                counted_starter_slots += 1
+
+        if counted_starter_slots > 0:
+            active_roster_size = starting_slots.get("ACTIVE_ROSTER_SIZE")
+            # Lineup slot totals are constrained by active starters, not total roster size.
+            # Fallback to roster_size only when ACTIVE_ROSTER_SIZE is not provided.
+            limit = active_roster_size if isinstance(active_roster_size, int) else roster_size
+            if isinstance(limit, int) and total_slots > limit:
+                errors.setdefault("starting_slots", []).append(
+                    "sum of starting slots cannot exceed ACTIVE_ROSTER_SIZE"
+                )
 
     if not isinstance(scoring_rules, list) or len(scoring_rules) == 0:
         errors.setdefault("scoring_rules", []).append("must include at least one scoring rule")

--- a/backend/tests/test_validation_service.py
+++ b/backend/tests/test_validation_service.py
@@ -174,6 +174,80 @@ def test_league_settings_dynamic_rules_detect_invalid_combinations():
     assert "waiver_tiebreaker" in report.errors
 
 
+def test_league_settings_dynamic_rules_ignore_metadata_slot_keys_in_sum_check():
+    report = validate_league_settings_dynamic_rules(
+        {
+            "roster_size": 14,
+            "salary_cap": 200,
+            "starting_slots": {
+                "QB": 1,
+                "RB": 2,
+                "WR": 2,
+                "TE": 1,
+                "K": 1,
+                "DEF": 1,
+                "FLEX": 1,
+                "ACTIVE_ROSTER_SIZE": 9,
+                "MAX_QB": 2,
+                "MAX_RB": 4,
+                "MAX_WR": 5,
+                "MAX_TE": 3,
+                "MAX_K": 0,
+                "MAX_DEF": 1,
+                "MAX_FLEX": 0,
+                "ALLOW_PARTIAL_LINEUP": 1,
+                "REQUIRE_WEEKLY_SUBMIT": 1,
+            },
+            "waiver_deadline": "Wed 11PM",
+            "starting_waiver_budget": 100,
+            "waiver_system": "FAAB",
+            "waiver_tiebreaker": "standings",
+            "trade_deadline": None,
+            "draft_year": 2026,
+            "scoring_rules": [{"category": "passing", "event_name": "TD", "point_value": 4}],
+        }
+    )
+
+    assert report.valid is True
+
+
+def test_league_settings_dynamic_rules_use_active_roster_size_for_slot_cap():
+    report = validate_league_settings_dynamic_rules(
+        {
+            "roster_size": 8,
+            "salary_cap": 200,
+            "starting_slots": {
+                "QB": 1,
+                "RB": 2,
+                "WR": 2,
+                "TE": 1,
+                "K": 0,
+                "DEF": 1,
+                "FLEX": 0,
+                "ACTIVE_ROSTER_SIZE": 9,
+                "MAX_QB": 2,
+                "MAX_RB": 4,
+                "MAX_WR": 5,
+                "MAX_TE": 3,
+                "MAX_K": 0,
+                "MAX_DEF": 1,
+                "MAX_FLEX": 0,
+                "ALLOW_PARTIAL_LINEUP": 1,
+                "REQUIRE_WEEKLY_SUBMIT": 1,
+            },
+            "waiver_deadline": "Wed 11PM",
+            "starting_waiver_budget": 100,
+            "waiver_system": "FAAB",
+            "waiver_tiebreaker": "standings",
+            "trade_deadline": None,
+            "draft_year": 2026,
+            "scoring_rules": [{"category": "passing", "event_name": "TD", "point_value": 4}],
+        }
+    )
+
+    assert report.valid is True
+
+
 def test_playoff_settings_boundary_invalid_payload():
     report = validate_playoff_settings_boundary(
         {

--- a/frontend/src/pages/DraftDayAnalyzer.jsx
+++ b/frontend/src/pages/DraftDayAnalyzer.jsx
@@ -168,6 +168,7 @@ export default function DraftDayAnalyzer({ activeOwnerId, activeLeagueId }) {
   const [drawerLoading, setDrawerLoading] = useState(false);
   const [drawerError, setDrawerError] = useState('');
   const [drawerContent, setDrawerContent] = useState(null);
+  const [leaguePositionCaps, setLeaguePositionCaps] = useState(POSITION_CAPS);
 
   const listRef = useRef(null);
 
@@ -232,6 +233,16 @@ export default function DraftDayAnalyzer({ activeOwnerId, activeLeagueId }) {
         if (data?.draft_year) {
           setDraftYear(Number(data.draft_year));
         }
+        const slots = data?.starting_slots || {};
+        const caps = {
+          QB: parseNumber(slots.MAX_QB, POSITION_CAPS.QB),
+          RB: parseNumber(slots.MAX_RB, POSITION_CAPS.RB),
+          WR: parseNumber(slots.MAX_WR, POSITION_CAPS.WR),
+          TE: parseNumber(slots.MAX_TE, POSITION_CAPS.TE),
+          DEF: parseNumber(slots.MAX_DEF, POSITION_CAPS.DEF),
+          K: parseNumber(slots.MAX_K, POSITION_CAPS.K),
+        };
+        setLeaguePositionCaps(caps);
       })
       .catch(() => {});
   }, [activeLeagueId]);
@@ -543,8 +554,8 @@ export default function DraftDayAnalyzer({ activeOwnerId, activeLeagueId }) {
       })
       .sort((a, b) => b.budget - a.budget);
 
-    const byPositionDemand = Object.keys(POSITION_CAPS).map((position) => {
-      const totalRequired = parseNumber(POSITION_CAPS[position], 0) * ownerCount;
+    const byPositionDemand = Object.keys(leaguePositionCaps).map((position) => {
+      const totalRequired = parseNumber(leaguePositionCaps[position], 0) * ownerCount;
       const alreadyDrafted = draftedByPosition[position] || 0;
       const remainingSlots = Math.max(0, totalRequired - alreadyDrafted);
       const availableCount = availableByPosition[position] || 0;
@@ -577,6 +588,7 @@ export default function DraftDayAnalyzer({ activeOwnerId, activeLeagueId }) {
     draftedPlayerIds.size,
     history,
     rankingByPlayerId,
+    leaguePositionCaps,
   ]);
 
   const ownerStrategyInsights = useMemo(() => {
@@ -588,7 +600,7 @@ export default function DraftDayAnalyzer({ activeOwnerId, activeLeagueId }) {
     const ownerBudget = parseNumber(owner.initial_budget || 200, 200);
     const ownerRemaining = Math.max(0, ownerBudget - ownerSpent);
 
-    const positionalBalance = Object.keys(POSITION_CAPS).map((position) => ({
+    const positionalBalance = Object.keys(leaguePositionCaps).map((position) => ({
       position,
       owner: history.filter(
         (pick) =>
@@ -653,6 +665,7 @@ export default function DraftDayAnalyzer({ activeOwnerId, activeLeagueId }) {
     selectedInsightRecommendation,
     selectedPlayer,
     draftDynamics.leagueAvgBudget,
+    leaguePositionCaps,
   ]);
 
   const availableHistoricalRankings = useMemo(() => {

--- a/frontend/src/pages/commissioner/LineupRules.jsx
+++ b/frontend/src/pages/commissioner/LineupRules.jsx
@@ -90,8 +90,11 @@ export default function LineupRules() {
         MAX_WR: clamp(wrLimit, 1, 5),
         MAX_TE: clamp(teLimit, 1, 3),
         MAX_K: kEnabled ? 1 : 0,
+        K: kEnabled ? 1 : 0,
         MAX_DEF: 1,
+        DEF: 1,
         MAX_FLEX: flexEnabled ? 1 : 0,
+        FLEX: flexEnabled ? 1 : 0,
         TAXI_SIZE: clamp(taxiSize, 0, 5),
         ALLOW_PARTIAL_LINEUP: allowPartialLineup ? 1 : 0,
         REQUIRE_WEEKLY_SUBMIT: requireWeeklySubmit ? 1 : 0,
@@ -106,7 +109,21 @@ export default function LineupRules() {
       setBaseConfig(payload);
       setSuccess('Lineup rules saved.');
     } catch (err) {
-      setError(err.response?.data?.detail || 'Failed to save lineup rules.');
+      // Safely extract error message, handling both string and object responses
+      let errorMsg = 'Failed to save lineup rules.';
+      if (err.response?.data) {
+        const data = err.response.data;
+        // Prefer detail field (standard FastAPI error format)
+        if (typeof data.detail === 'string') {
+          errorMsg = data.detail;
+        } else if (typeof data === 'string') {
+          errorMsg = data;
+        } else if (typeof data.detail === 'object') {
+          // If detail is still an object, stringify it safely for debugging
+          errorMsg = `Validation error: ${JSON.stringify(data.detail)}`;
+        }
+      }
+      setError(errorMsg);
     } finally {
       setSaving(false);
     }

--- a/frontend/tests/LineupRules.test.jsx
+++ b/frontend/tests/LineupRules.test.jsx
@@ -1,0 +1,204 @@
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('../src/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ to, children, ...props }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import LineupRules from '../src/pages/commissioner/LineupRules';
+import apiClient from '../src/api/client';
+
+const BASE_SLOTS = {
+  QB: 1,
+  RB: 2,
+  WR: 2,
+  TE: 1,
+  K: 1,
+  DEF: 1,
+  FLEX: 1,
+  ACTIVE_ROSTER_SIZE: 9,
+  MAX_QB: 3,
+  MAX_RB: 5,
+  MAX_WR: 5,
+  MAX_TE: 3,
+  MAX_K: 1,
+  MAX_DEF: 1,
+  MAX_FLEX: 1,
+  TAXI_SIZE: 0,
+  ALLOW_PARTIAL_LINEUP: 0,
+  REQUIRE_WEEKLY_SUBMIT: 1,
+};
+
+const BASE_CONFIG = {
+  league_id: 1,
+  scoring_rules: [],
+  starting_slots: BASE_SLOTS,
+};
+
+describe('LineupRules', () => {
+  beforeEach(() => {
+    localStorage.setItem('fantasyLeagueId', '1');
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('renders loading state initially', () => {
+    apiClient.get.mockImplementation(() => new Promise(() => {}));
+    render(<LineupRules />);
+    expect(screen.getByText(/loading lineup rules/i)).toBeInTheDocument();
+  });
+
+  test('loads and displays commissioner-configured values', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: BASE_CONFIG });
+    render(<LineupRules />);
+    await waitFor(() => {
+      expect(screen.getByText(/Total Active Roster Required/i)).toBeInTheDocument();
+      expect(screen.getByText(/Save Lineup Rules/i)).toBeInTheDocument();
+    });
+  });
+
+  test('save includes K slot-count key matching kEnabled toggle (K enabled)', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: BASE_CONFIG });
+    apiClient.put.mockResolvedValueOnce({ data: {} });
+
+    render(<LineupRules />);
+    await waitFor(() =>
+      expect(screen.getByText(/Save Lineup Rules/i)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(/Save Lineup Rules/i));
+
+    await waitFor(() => expect(apiClient.put).toHaveBeenCalledTimes(1));
+
+    const [, payload] = apiClient.put.mock.calls[0];
+    const slots = payload.starting_slots;
+    // K slot-count key must equal MAX_K when K is enabled
+    expect(slots.K).toBe(1);
+    expect(slots.MAX_K).toBe(1);
+  });
+
+  test('save includes K slot-count = 0 when K is disabled', async () => {
+    const configWithKDisabled = {
+      ...BASE_CONFIG,
+      starting_slots: { ...BASE_SLOTS, MAX_K: 0, K: 0 },
+    };
+    apiClient.get.mockResolvedValueOnce({ data: configWithKDisabled });
+    apiClient.put.mockResolvedValueOnce({ data: {} });
+
+    render(<LineupRules />);
+    await waitFor(() =>
+      expect(screen.getByText(/Save Lineup Rules/i)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(/Save Lineup Rules/i));
+
+    await waitFor(() => expect(apiClient.put).toHaveBeenCalledTimes(1));
+
+    const [, payload] = apiClient.put.mock.calls[0];
+    const slots = payload.starting_slots;
+    expect(slots.K).toBe(0);
+    expect(slots.MAX_K).toBe(0);
+  });
+
+  test('save includes FLEX slot-count key matching flexEnabled toggle', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: BASE_CONFIG });
+    apiClient.put.mockResolvedValueOnce({ data: {} });
+
+    render(<LineupRules />);
+    await waitFor(() =>
+      expect(screen.getByText(/Save Lineup Rules/i)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(/Save Lineup Rules/i));
+
+    await waitFor(() => expect(apiClient.put).toHaveBeenCalledTimes(1));
+
+    const [, payload] = apiClient.put.mock.calls[0];
+    const slots = payload.starting_slots;
+    expect(slots.FLEX).toBe(1);
+    expect(slots.MAX_FLEX).toBe(1);
+  });
+
+  test('save includes FLEX slot-count = 0 when FLEX is disabled', async () => {
+    const configWithFlexDisabled = {
+      ...BASE_CONFIG,
+      starting_slots: { ...BASE_SLOTS, MAX_FLEX: 0, FLEX: 0 },
+    };
+    apiClient.get.mockResolvedValueOnce({ data: configWithFlexDisabled });
+    apiClient.put.mockResolvedValueOnce({ data: {} });
+
+    render(<LineupRules />);
+    await waitFor(() =>
+      expect(screen.getByText(/Save Lineup Rules/i)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(/Save Lineup Rules/i));
+
+    await waitFor(() => expect(apiClient.put).toHaveBeenCalledTimes(1));
+
+    const [, payload] = apiClient.put.mock.calls[0];
+    const slots = payload.starting_slots;
+    expect(slots.FLEX).toBe(0);
+    expect(slots.MAX_FLEX).toBe(0);
+  });
+
+  test('save payload contains DEF slot-count key', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: BASE_CONFIG });
+    apiClient.put.mockResolvedValueOnce({ data: {} });
+
+    render(<LineupRules />);
+    await waitFor(() =>
+      expect(screen.getByText(/Save Lineup Rules/i)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(/Save Lineup Rules/i));
+
+    await waitFor(() => expect(apiClient.put).toHaveBeenCalledTimes(1));
+
+    const [, payload] = apiClient.put.mock.calls[0];
+    expect(payload.starting_slots.DEF).toBe(1);
+    expect(payload.starting_slots.MAX_DEF).toBe(1);
+  });
+
+  test('shows success message after save', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: BASE_CONFIG });
+    apiClient.put.mockResolvedValueOnce({ data: {} });
+
+    render(<LineupRules />);
+    await waitFor(() =>
+      expect(screen.getByText(/Save Lineup Rules/i)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(/Save Lineup Rules/i));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Lineup rules saved/i)).toBeInTheDocument()
+    );
+  });
+
+  test('shows error when no league is selected', async () => {
+    localStorage.removeItem('fantasyLeagueId');
+
+    render(<LineupRules />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/No active league selected/i)
+      ).toBeInTheDocument()
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes bug where commissioner lineup rules configured on the Commissioner Page were not correctly reflected on the Owner Page, causing permanent validation errors and mismatched positional requirements.

## Root Causes Fixed

### 1. K/FLEX slot-count keys missing from save payload (LineupRules.jsx)
When the commissioner toggled K or FLEX enabled/disabled, only \MAX_K\/\MAX_FLEX\ were written to \starting_slots\. The actual slot-count keys (\K\, \FLEX\, \DEF\) were never explicitly set, so they retained stale defaults from the initial spread.

On the owner page, \
ormalizeStartingSlots\ reads \slots.K\ for **minimum starters required**, while \maxPositionLimits\ reads \slots.MAX_K\ for the **max allowed**. When K is disabled, this produced min=1 / max=0 — a permanent contradiction that blocked lineup submission.

**Fix:** Explicitly write \K: kEnabled ? 1 : 0\, \FLEX: flexEnabled ? 1 : 0\, and \DEF: 1\ in the save payload.

### 2. DraftDayAnalyzer used hardcoded \POSITION_CAPS\ (DraftDayAnalyzer.jsx)
Position demand and owner strategy panels used \POSITION_CAPS = {QB:2, RB:5, WR:5, TE:2}\ regardless of the commissioner's \MAX_*\ settings. The existing \etchLeagueSettings\ call only extracted \draft_year\.

**Fix:** Extract \MAX_QB/RB/WR/TE/K/DEF\ from league settings and use them as live \leaguePositionCaps\, falling back to the static defaults if the API call fails.

### 3. Validation service counted metadata keys in slot sum (alidation_service.py)
The slot-sum check included metadata keys (\MAX_QB\, \ACTIVE_ROSTER_SIZE\, etc.) when validating that total slots ≤ active roster size. Adding \K:0\ and \FLEX:0\ would have incorrectly inflated the sum.

**Fix:** Only count keys without underscores (actual position slots: QB, RB, WR, TE, K, DEF, FLEX) in the sum check.

### 4. Validation errors were returned as raw dicts (league.py)
PUT /leagues/{id}/settings re-raised validation error dicts directly, causing the frontend to display \[object Object]\ instead of a readable message.

**Fix:** Add \ormat_validation_errors\ helper to convert error dicts to readable strings before returning them in \HTTPException\.

## Files Changed
- \rontend/src/pages/commissioner/LineupRules.jsx\ — explicit K/FLEX/DEF slot-count keys on save
- \rontend/src/pages/DraftDayAnalyzer.jsx\ — live \leaguePositionCaps\ from league settings
- \rontend/tests/LineupRules.test.jsx\ — 9 new tests for slot-count key correctness, save/error flows
- \ackend/services/validation_service.py\ — skip metadata keys in slot sum check
- \ackend/routers/league.py\ — \ormat_validation_errors\ helper + readable HTTP error messages
- \ackend/tests/test_validation_service.py\ — tests for metadata key exclusion in sum check

Closes #166