### PR TITLE
fix: scoring rules page unclear terminology, broken simulator, and st…

### DIFF
--- a/frontend/src/pages/commissioner/ManageScoringRules.jsx
+++ b/frontend/src/pages/commissioner/ManageScoringRules.jsx
@@ -31,6 +31,10 @@ const CALCULATION_TYPES = [
   { value: 'tiered', label: 'Tiered Range', help: 'Applies scoring by ranges using min/max bounds.' },
 ];
 
+const CALC_TYPE_LABEL = Object.fromEntries(
+  CALCULATION_TYPES.map((t) => [t.value, t.label])
+);
+
 const SOURCE_OPTIONS = [
   { value: 'custom', label: 'Custom Rule Set (manual)' },
   { value: 'template', label: 'Template Applied Rule' },
@@ -678,7 +682,7 @@ export default function ManageScoringRules() {
                   <StandardTableRow key={`${row.event_name}-${idx}`} className="hover:bg-transparent dark:hover:bg-transparent">
                     <td className={tableCell}>{row.category}</td>
                     <td className={tableCell}>{row.event_name}</td>
-                    <td className={tableCell}>{row.calculation_type}</td>
+                    <td className={tableCell}>{CALC_TYPE_LABEL[row.calculation_type] || row.calculation_type}</td>
                     <td className={tableCell}>{row.point_value}</td>
                     <td className={tableCell}>{(row.applicable_positions || []).join(', ') || 'ALL'}</td>
                   </StandardTableRow>
@@ -717,7 +721,7 @@ export default function ManageScoringRules() {
                     <td className={tableCell}>{rule.event_name}</td>
                     <td className={tableCell}>{rule.range_min}-{rule.range_max}</td>
                     <td className={tableCell}>{rule.point_value}</td>
-                    <td className={tableCell}>{rule.calculation_type}</td>
+                    <td className={tableCell}>{CALC_TYPE_LABEL[rule.calculation_type] || rule.calculation_type}</td>
                     <td className={tableCell}>{(rule.applicable_positions || []).join(', ') || 'ALL'}</td>
                     <td className={tableCell}>{rule.season_year || 'All seasons'}</td>
                     <td className={tableCell}>
@@ -789,10 +793,13 @@ export default function ManageScoringRules() {
             </div>
             {Array.isArray(simResult.breakdown) && simResult.breakdown.length > 0 ? (
               <div className={textCaption}>
-                Breakdown: {simResult.breakdown.map((item) => `${item.event_name}: ${item.points_awarded}`).join(' | ')}
+                Breakdown: {simResult.breakdown.map((item) => `${item.event_name}: ${item.points}`).join(' | ')}
               </div>
-            ) : null}
-          </div>
+            ) : null}            {simResult.rules_evaluated === 0 && (
+              <div className={textMuted}>
+                No scoring rules are configured for this league yet. Add rules above to see a point breakdown.
+              </div>
+            )}          </div>
         )}
       </div>
 

--- a/frontend/src/pages/commissioner/components/ScoringRulesModal.jsx
+++ b/frontend/src/pages/commissioner/components/ScoringRulesModal.jsx
@@ -1,32 +1,98 @@
 /* ignore-breakpoints: modal layout and responsiveness are handled by shared uiStandards modal classes; no additional breakpoint-specific behaviour is required */
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { FiSettings } from 'react-icons/fi';
+import apiClient from '@api/client';
+import { normalizeApiError } from '@api/fetching';
 import {
   modalCloseButton,
   modalDescription,
   modalOverlay,
-  modalPlaceholder,
   modalSurface,
   modalTitle,
+  tableCell,
+  textMuted,
 } from '@utils/uiStandards';
 
+const CALC_TYPE_LABEL = {
+  flat_bonus: 'Flat Bonus',
+  per_unit: 'Per Unit',
+  decimal: 'Decimal',
+  ppr: 'PPR',
+  half_ppr: 'Half-PPR',
+  tiered: 'Tiered Range',
+};
+
 export default function ScoringRulesModal({ open, onClose }) {
+  const [rules, setRules] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError('');
+    apiClient
+      .get('/scoring/rules?include_inactive=false')
+      .then((res) => setRules(Array.isArray(res.data) ? res.data : []))
+      .catch((err) => setError(normalizeApiError(err, 'Failed to load scoring rules.')))
+      .finally(() => setLoading(false));
+  }, [open]);
+
   if (!open) return null;
+
   return (
     <div className={modalOverlay}>
-      <div className={modalSurface}>
+      <div className={`${modalSurface} max-w-3xl w-full`}>
         <button onClick={onClose} className={modalCloseButton}>
           ✕
         </button>
         <h2 className={modalTitle}>
-          <FiSettings /> Set Scoring Rules
+          <FiSettings className="inline mr-1" /> League Scoring Rules
         </h2>
         <p className={modalDescription}>
-          Configure how points are awarded for all league actions.
+          Current active scoring rules configured by your commissioner.
         </p>
-        <div className={modalPlaceholder}>
-          Scoring rules form coming soon...
-        </div>
+
+        {loading && (
+          <p className={`${textMuted} mt-3`}>Loading rules…</p>
+        )}
+        {error && (
+          <p className="mt-3 text-sm text-red-400">{error}</p>
+        )}
+        {!loading && !error && rules.length === 0 && (
+          <p className={`${textMuted} mt-3`}>No scoring rules have been configured for this league yet.</p>
+        )}
+        {!loading && !error && rules.length > 0 && (
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+                  <th className="py-2 pr-3">Category</th>
+                  <th className="py-2 pr-3">Event</th>
+                  <th className="py-2 pr-3">Type</th>
+                  <th className="py-2 pr-3">Points</th>
+                  <th className="py-2 pr-3">Positions</th>
+                  <th className="py-2">Season</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rules.map((rule) => (
+                  <tr
+                    key={rule.id}
+                    className="border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-800/50"
+                  >
+                    <td className={tableCell}>{rule.category}</td>
+                    <td className={tableCell}>{rule.event_name}</td>
+                    <td className={tableCell}>{CALC_TYPE_LABEL[rule.calculation_type] || rule.calculation_type}</td>
+                    <td className={tableCell}>{rule.point_value}</td>
+                    <td className={tableCell}>{(rule.applicable_positions || []).join(', ') || 'ALL'}</td>
+                    <td className={tableCell}>{rule.season_year || 'All seasons'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/tests/ManageScoringRules.test.jsx
+++ b/frontend/tests/ManageScoringRules.test.jsx
@@ -126,4 +126,64 @@ describe('ManageScoringRules page', () => {
       expect(screen.getByText(/Total Preview Points: 18/i)).toBeInTheDocument();
     });
   });
+
+  test('simulator breakdown uses points field (not points_awarded)', async () => {
+    apiClient.post.mockResolvedValueOnce({
+      data: {
+        points: 12,
+        rules_evaluated: 2,
+        breakdown: [
+          { event_name: 'passing_tds', points: 8 },
+          { event_name: 'passing_yards', points: 4 },
+        ],
+      },
+    });
+
+    render(<ManageScoringRules />);
+    fireEvent.click(screen.getByRole('button', { name: /Run Preview/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/passing_tds: 8/)).toBeInTheDocument();
+      expect(screen.getByText(/passing_yards: 4/)).toBeInTheDocument();
+    });
+  });
+
+  test('simulator shows no-rules hint when rules_evaluated is 0', async () => {
+    apiClient.post.mockResolvedValueOnce({
+      data: { points: 0, rules_evaluated: 0, breakdown: [] },
+    });
+
+    render(<ManageScoringRules />);
+    fireEvent.click(screen.getByRole('button', { name: /Run Preview/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No scoring rules are configured/i)).toBeInTheDocument();
+    });
+  });
+
+  test('current rules table shows human-readable calculation type label', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          category: 'passing',
+          event_name: 'passing_yards',
+          range_min: 0,
+          range_max: 999,
+          point_value: 0.04,
+          calculation_type: 'per_unit',
+          applicable_positions: ['QB'],
+          season_year: null,
+        },
+      ],
+    });
+
+    render(<ManageScoringRules />);
+
+    await waitFor(() => {
+      // Should show the label, not the raw value
+      expect(screen.getByText('Per Unit')).toBeInTheDocument();
+      expect(screen.queryByText('per_unit')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/tests/ScoringRulesModal.test.jsx
+++ b/frontend/tests/ScoringRulesModal.test.jsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('../src/api/client', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import ScoringRulesModal from '../src/pages/commissioner/components/ScoringRulesModal';
+import apiClient from '../src/api/client';
+
+describe('ScoringRulesModal', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('renders nothing when closed', () => {
+    const { container } = render(<ScoringRulesModal open={false} onClose={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('fetches and displays scoring rules when opened', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          category: 'passing',
+          event_name: 'passing_tds',
+          calculation_type: 'flat_bonus',
+          point_value: 4,
+          applicable_positions: ['QB'],
+          season_year: 2026,
+        },
+      ],
+    });
+
+    render(<ScoringRulesModal open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining('/scoring/rules')
+      );
+      expect(screen.getByText('passing_tds')).toBeInTheDocument();
+    });
+  });
+
+  test('shows human-readable calculation type label', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 2,
+          category: 'receiving',
+          event_name: 'receptions',
+          calculation_type: 'ppr',
+          point_value: 1,
+          applicable_positions: [],
+          season_year: null,
+        },
+      ],
+    });
+
+    render(<ScoringRulesModal open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('PPR')).toBeInTheDocument();
+      expect(screen.queryByText('ppr')).not.toBeInTheDocument();
+    });
+  });
+
+  test('shows no-rules message when list is empty', async () => {
+    apiClient.get.mockResolvedValueOnce({ data: [] });
+
+    render(<ScoringRulesModal open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No scoring rules have been configured/i)).toBeInTheDocument();
+    });
+  });
+
+  test('shows error when fetch fails', async () => {
+    apiClient.get.mockRejectedValueOnce({ message: 'Failed to load scoring rules.' });
+
+    render(<ScoringRulesModal open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load scoring rules/i)).toBeInTheDocument();
+    });
+  });
+
+  test('shows All seasons when season_year is null', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: 3,
+          category: 'rushing',
+          event_name: 'rushing_yards',
+          calculation_type: 'per_unit',
+          point_value: 0.1,
+          applicable_positions: ['RB'],
+          season_year: null,
+        },
+      ],
+    });
+
+    render(<ScoringRulesModal open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('All seasons')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
…ub modal (#177)

- ManageScoringRules.jsx: fix simulator breakdown field name from points_awarded to points, matching the CalculatedRuleResult dataclass field. Previously the breakdown line showed 'Event: undefined' for every rule.

- ManageScoringRules.jsx: add CALC_TYPE_LABEL lookup so the Current Rules table and CSV preview table show human-readable labels ('Flat Bonus', 'Per Unit', etc.) instead of raw backend values ('flat_bonus', 'per_unit').

- ManageScoringRules.jsx: show a contextual hint when the simulator runs and rules_evaluated is 0 so commissioners know they need to add rules rather than assuming the simulator is broken.

- ScoringRulesModal.jsx: replace 'coming soon' stub with a real read-only view that fetches GET /scoring/rules and renders them in a table. Owners can now see the active scoring rules from the Locker Room without having to navigate to the Commissioner page.

- tests/ManageScoringRules.test.jsx: add 3 new tests covering breakdown field name, no-rules simulator hint, and human-readable calc type label.
- tests/ScoringRulesModal.test.jsx: new file, 6 tests for the modal (open/closed state, rules display, empty state, error, labels, seasons).

## Summary

- Short description of the change (1–3 lines):
- Related issue(s): # (if any)
- Type of change: bugfix / feature / chore / docs / tests / refactor / breaking change

## Motivation

Why this change is needed and the high-level approach.

## How to test locally

Backend
- Ensure a dev database is available (see README or project docs).
- From repo root:
  - cd backend
  - Install dependencies (replace with your install tool if not pip): `pip install -r requirements.txt`
  - Seed DB if needed (project-specific): `./scripts/seed_db.sh` (or see README)
  - Run tests: `pytest -q`

Frontend
- From repo root:
  - cd frontend
  - Install deps: `npm ci`
  - Run unit tests: `npm test`
  - Lint/format: `npm run lint` / `npm run format`

End-to-end
- Start the dev server (as described in README)
- From repo root or frontend/: `npm run e2e`

CI
- CI runs: backend pytest (with coverage), frontend lint & tests, and Cypress E2E. Make sure your PR passes those checks.

## Checklist (required before marking ready)
- [ ] I added/updated tests covering the change
- [ ] I updated any relevant documentation (README, migrations, or CHANGELOG)
- [ ] Linter/formatters pass locally (pre-commit)
- [ ] No secrets or large binaries added
- [ ] CI checks are green (or explained why not)

## Security checklist (required for auth, API, infra, or dependency changes)
- [ ] Inputs are validated server-side and errors do not leak sensitive internals
- [ ] Protected endpoints enforce auth/role boundaries as expected
- [ ] No credentials/tokens are stored in plain text or committed artifacts
- [ ] New dependencies were reviewed for known vulnerabilities
- [ ] Added/changed headers, CORS, or auth behavior is validated locally

## Notes for reviewers
- Any migration / data changes to be aware of:
- Any backwards compatibility considerations:
- Expected runtime / performance changes:
- Any special steps for deploy / post-merge:

If this is a draft PR, mark it as Draft — I will not request a full review until ready.
