### PR TITLE
Issue #181: rebrand frontend to PPL Insight Hub

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# Frontend (Fantasy Football PI)
+# Frontend (PPL Insight Hub)
 
-Vite + React frontend for the Fantasy Football PI app.
+Vite + React frontend for the PPL Insight Hub app.
 
 ## Quick Start
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>PPL Insight Hub</title>
   </head>
   <body>
     <script>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,9 +12,11 @@ import './App.css';
 
 // Import Components
 import Layout from './components/Layout';
+import BrandMark from './components/BrandMark';
 import LeagueSelector from './components/LeagueSelector';
 import LeagueAdvisor from './components/LeagueAdvisor';
 import { LoadingState } from '@components/common/AsyncState';
+import { BRAND_NAME } from './constants/branding';
 import { ThemeProvider } from './context/ThemeContext';
 
 // Import Pages (Lazy Loaded)
@@ -91,7 +93,7 @@ function resolveLayoutPageTitle(pathname) {
   if (pathname === '/keepers') return 'Manage Keepers';
   if (pathname === '/analytics') return 'League Analytics';
   if (pathname === '/playoffs') return 'Playoff Bracket';
-  return 'Fantasy Pi';
+  return BRAND_NAME;
 }
 
 function AuthenticatedShell({
@@ -104,6 +106,10 @@ function AuthenticatedShell({
 }) {
   const location = useLocation();
   const headerTitle = resolveLayoutPageTitle(location.pathname);
+
+  useEffect(() => {
+    document.title = headerTitle ? `${headerTitle} | ${BRAND_NAME}` : BRAND_NAME;
+  }, [headerTitle]);
 
   return (
     <Layout
@@ -294,6 +300,12 @@ function App() {
       .catch(() => setLayoutAlert(''));
   }, [activeLeagueId, token]);
 
+  useEffect(() => {
+    if (!token) {
+      document.title = `${BRAND_NAME} Login`;
+    }
+  }, [token]);
+
   // --- 1.5 LOGIN HANDLER ---
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -335,14 +347,12 @@ function App() {
           className="bg-slate-800 p-8 rounded-lg shadow-2xl w-96 border border-slate-700"
         >
           <div className="flex flex-col items-center mb-6">
-            <img
-              src={import.meta.env.BASE_URL + 'src/assets/react.svg'}
-              alt="FantasyFootball-PI Logo"
-              className="w-16 h-16 mb-2"
+            <BrandMark
+              containerClassName="flex flex-col items-center"
+              imageClassName="w-16 h-16 mb-2"
+              textClassName="text-3xl font-black text-center text-yellow-500 tracking-tighter"
+              text={`${BRAND_NAME} Login`}
             />
-            <h2 className="text-3xl font-black text-center text-yellow-500 tracking-tighter">
-              FantasyFootball-PI Login
-            </h2>
           </div>
           {error && (
             <div className="mb-4 text-red-400 text-center text-sm font-bold">

--- a/frontend/src/components/BrandMark.jsx
+++ b/frontend/src/components/BrandMark.jsx
@@ -1,0 +1,19 @@
+import { BRAND_LOGO_ALT, BRAND_NAME } from '../constants/branding';
+
+export default function BrandMark({
+  containerClassName = 'flex items-center gap-2',
+  imageClassName = 'w-8 h-8',
+  textClassName = '',
+  text = BRAND_NAME,
+}) {
+  return (
+    <div className={containerClassName}>
+      <img
+        src={import.meta.env.BASE_URL + 'src/assets/react.svg'}
+        alt={BRAND_LOGO_ALT}
+        className={imageClassName}
+      />
+      <span className={textClassName}>{text}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { FiMenu } from 'react-icons/fi';
 import { layoutAlertBar, layerNav } from '../utils/uiStandards';
+import BrandMark from './BrandMark';
 import Sidebar from './Sidebar';
 import ThemeToggle from './ThemeToggle';
 
@@ -25,14 +26,10 @@ export default function Layout({ children, username, leagueId, alert, pageTitle 
           </button>
 
           {/* Branding */}
-          <div className="hidden sm:flex items-center gap-2 font-black text-xl tracking-tighter italic uppercase">
-            <img
-              src={import.meta.env.BASE_URL + 'src/assets/react.svg'}
-              alt="FantasyFootball-PI Logo"
-              className="w-8 h-8"
-            />
-            FANTASY<span className="text-slate-600">Pi</span>
-          </div>
+          <BrandMark
+            containerClassName="hidden sm:flex items-center gap-2 font-black text-xl tracking-tighter italic"
+            imageClassName="w-8 h-8"
+          />
         </div>
 
         <div className="ml-auto flex items-center gap-3 min-w-0">

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import apiClient from '@api/client';
 import { layerBackdrop, layerDrawer } from '@utils/uiStandards';
+import BrandMark from './BrandMark';
 
 import {
   FiX,
@@ -87,16 +88,11 @@ export default function Sidebar({ isOpen, onClose, username, leagueId }) {
         }`}
       >
         <div className="flex items-center justify-between border-b border-slate-300 bg-slate-100 p-6 dark:border-slate-800 dark:bg-slate-900">
-          <div className="flex items-center gap-2">
-            <img
-              src={import.meta.env.BASE_URL + 'src/assets/react.svg'}
-              alt="FantasyFootball-PI Logo"
-              className="w-7 h-7"
-            />
-            <h2 className="text-2xl font-black tracking-tighter text-slate-900 dark:text-white">
-              FANTASY<span className="text-cyan-500">Pi</span>
-            </h2>
-          </div>
+          <BrandMark
+            containerClassName="flex items-center gap-2"
+            imageClassName="w-7 h-7"
+            textClassName="text-2xl font-black tracking-tighter text-slate-900 dark:text-white"
+          />
           <p className="text-xs text-slate-500 dark:text-slate-400">
             {leagueName ? leagueName : 'League'}
           </p>

--- a/frontend/src/constants/branding.js
+++ b/frontend/src/constants/branding.js
@@ -1,0 +1,2 @@
+export const BRAND_NAME = 'PPL Insight Hub';
+export const BRAND_LOGO_ALT = `${BRAND_NAME} Logo`;

--- a/frontend/tests/App.test.jsx
+++ b/frontend/tests/App.test.jsx
@@ -59,7 +59,7 @@ describe('App (basic)', () => {
 
   test('renders login screen when no token present', () => {
     render(<App />);
-    expect(screen.getByText(/FantasyFootball-PI Login/i)).toBeInTheDocument();
+    expect(screen.getByText(/PPL Insight Hub Login/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Enter username/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Enter password/i)).toBeInTheDocument();
     // Test for new League ID input (from recent changes)
@@ -165,7 +165,7 @@ describe('App (basic)', () => {
       expect(localStorage.getItem('user_id')).toBeNull();
       expect(localStorage.getItem('fantasyLeagueId')).toBeNull();
     });
-    expect(screen.getByText(/FantasyFootball-PI Login/i)).toBeInTheDocument();
+    expect(screen.getByText(/PPL Insight Hub Login/i)).toBeInTheDocument();
   });
 
   test('visiting /playoffs renders playoff bracket', async () => {


### PR DESCRIPTION
## Summary
- add centralized frontend branding constants and shared BrandMark component
- replace legacy Fantasy PI branding in login, top nav, sidebar, and fallback page title
- update document title behavior and frontend metadata title to PPL Insight Hub
- update App branding tests and frontend README naming

## Validation
- npm run test -- --run tests/App.test.jsx
- npm run lint -- src/App.jsx src/components/Layout.jsx src/components/Sidebar.jsx src/components/BrandMark.jsx tests/App.test.jsx
- npm run build

Closes #181