### PR TITLE
fix: Draft Day Analyzer duplicate players regression (#278)

### DIFF
--- a/backend/services/player_service.py
+++ b/backend/services/player_service.py
@@ -209,10 +209,19 @@ def canonical_player_rank(player: models.Player) -> tuple[int, int]:
 
 
 def dedupe_players(players: list[models.Player]) -> list[models.Player]:
-    selected: dict[tuple, models.Player] = {}
+    # Defensive first pass: guarantee unique player IDs even if upstream query
+    # shape ever returns duplicate rows for the same primary key.
+    selected_by_id: dict[int, models.Player] = {}
     for player in players:
         if not is_valid_player_row(player):
             continue
+        player_id = int(player.id or 0)
+        current_by_id = selected_by_id.get(player_id)
+        if current_by_id is None or _player_rank(player) > _player_rank(current_by_id):
+            selected_by_id[player_id] = player
+
+    selected: dict[tuple, models.Player] = {}
+    for player in selected_by_id.values():
         key = _player_dedupe_key(player)
         current = selected.get(key)
         if current is None or _player_rank(player) > _player_rank(current):

--- a/backend/tests/test_players_router.py
+++ b/backend/tests/test_players_router.py
@@ -212,6 +212,60 @@ def test_player_quality_report_requires_commissioner(client):
             cleanup.close()
 
 
+def test_players_endpoint_dedupes_identity_variants(client):
+    suffix = uuid4().hex[:8]
+    created_ids: list[int] = []
+
+    session = SessionLocal()
+    try:
+        player_with_external = models.Player(
+            name=f"{suffix}. Example Jr.",
+            position="WR",
+            nfl_team="BUF",
+            espn_id=f"espn-{suffix}",
+            projected_points=3210.0,
+            adp=101.0,
+        )
+        player_without_external = models.Player(
+            name=f"{suffix} Example",
+            position="WR",
+            nfl_team="BAL",
+            projected_points=3200.0,
+            adp=102.0,
+        )
+        session.add_all([player_with_external, player_without_external])
+        session.commit()
+        created_ids = [
+            row.id
+            for row in (player_with_external, player_without_external)
+            if row.id is not None
+        ]
+    finally:
+        session.close()
+
+    try:
+        response = client.get("/players/")
+        assert response.status_code == 200
+        rows = response.json()
+        matching = [
+            row
+            for row in rows
+            if suffix.lower() in str(row.get("name", "")).lower()
+        ]
+        assert len(matching) == 1
+        assert matching[0].get("espn_id") == f"espn-{suffix}"
+    finally:
+        cleanup = SessionLocal()
+        try:
+            if created_ids:
+                cleanup.query(models.Player).filter(
+                    models.Player.id.in_(created_ids)
+                ).delete(synchronize_session=False)
+                cleanup.commit()
+        finally:
+            cleanup.close()
+
+
 def test_player_quality_report_returns_expected_shape_for_commissioner(client):
     suffix = uuid4().hex[:8]
     league_id = None

--- a/frontend/src/api/draftAnalyzerApi.js
+++ b/frontend/src/api/draftAnalyzerApi.js
@@ -40,9 +40,32 @@ function buildFallbackPlayerKey(player) {
 
 function dedupePlayersForUi(players) {
   const list = Array.isArray(players) ? players : [];
-  const selected = new Map();
+  const byId = new Map();
 
   for (const player of list) {
+    const playerId = Number(player?.id || 0);
+    if (!playerId) continue;
+    const currentById = byId.get(playerId);
+    const playerHasExternal = Boolean(player?.gsis_id || player?.espn_id);
+    const currentHasExternal = Boolean(currentById?.gsis_id || currentById?.espn_id);
+    const playerIsActiveTeam = normalizeText(player?.nfl_team) !== 'fa';
+    const currentIsActiveTeam = normalizeText(currentById?.nfl_team) !== 'fa';
+
+    const shouldReplaceById =
+      !currentById ||
+      (playerHasExternal && !currentHasExternal) ||
+      (playerHasExternal === currentHasExternal && playerIsActiveTeam && !currentIsActiveTeam) ||
+      (playerHasExternal === currentHasExternal && playerIsActiveTeam === currentIsActiveTeam && Number(player?.id || 0) > Number(currentById?.id || 0));
+
+    if (shouldReplaceById) {
+      byId.set(playerId, player);
+    }
+  }
+
+  const canonicalList = Array.from(byId.values());
+  const selected = new Map();
+
+  for (const player of canonicalList) {
     const key = buildFallbackPlayerKey(player);
     const current = selected.get(key);
     const playerHasExternal = Boolean(player?.gsis_id || player?.espn_id);

--- a/frontend/tests/DraftDayAnalyzer.test.jsx
+++ b/frontend/tests/DraftDayAnalyzer.test.jsx
@@ -46,6 +46,13 @@ const playersPayload = [
   { id: 103, name: 'Player C', nfl_team: 'SF', position: 'RB' },
 ];
 
+const duplicatePlayersPayload = [
+  { id: 101, name: 'A.J. Player Jr.', nfl_team: 'BUF', position: 'WR', espn_id: '101' },
+  { id: 104, name: 'AJ Player', nfl_team: 'BAL', position: 'WR' },
+  { id: 102, name: 'Player B', nfl_team: 'KC', position: 'WR', espn_id: '102' },
+  { id: 103, name: 'Player C', nfl_team: 'SF', position: 'RB', espn_id: '103' },
+];
+
 const rankingsPayload = [
   { player_id: 101, rank: 1, player_name: 'Player A', position: 'WR', predicted_auction_value: 50, confidence_score: 80, consensus_tier: 'A' },
   { player_id: 102, rank: 2, player_name: 'Player B', position: 'WR', predicted_auction_value: 46, confidence_score: 78, consensus_tier: 'A' },
@@ -243,5 +250,26 @@ describe('DraftDayAnalyzer advisor actions', () => {
     await waitFor(() =>
       expect(getVisiblePlayerRows()[0]).toHaveTextContent('Player A')
     );
+  });
+
+  test('hides duplicate player identities in analyzer list', async () => {
+    const baseGet = buildGetMock();
+    apiClient.get = vi.fn((url, config = {}) => {
+      if (url === '/players/') {
+        return Promise.resolve({ data: duplicatePlayersPayload });
+      }
+      return baseGet(url, config);
+    });
+
+    render(<DraftDayAnalyzer activeOwnerId={1} activeLeagueId={1} />);
+
+    await screen.findByRole('button', { name: /Player B/i });
+
+    await waitFor(() => {
+      const dedupedRows = screen.getAllByRole('button').filter((row) =>
+        /AJ Player|A\.J\. Player/i.test(row.textContent || '')
+      );
+      expect(dedupedRows).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes issue #278 where duplicate players can reappear in Draft Day Analyzer.

## What changed

### Backend hardening
- `backend/services/player_service.py`
- Added a defensive first pass in `dedupe_players` to enforce uniqueness by `player.id` before identity-level collapsing.
- Existing identity dedupe still applies after by-id compaction.

### Frontend hardening
- `frontend/src/api/draftAnalyzerApi.js`
- Strengthened `dedupePlayersForUi` with a by-id uniqueness pass before fallback identity dedupe.
- Keeps UI guarded even if backend returns duplicate rows in a failure scenario.

## Regression tests

### Backend
- `backend/tests/test_players_router.py`
- Added `test_players_endpoint_dedupes_identity_variants` to verify `/players/` collapses name variants into one canonical row.

### Frontend
- `frontend/tests/DraftDayAnalyzer.test.jsx`
- Added `hides duplicate player identities in analyzer list` to verify Draft Analyzer list hides duplicate identities.

## Validation run
- `python3.13.exe -m pytest tests/test_players_router.py -q -k dedupes_identity_variants` ✅
- `npm run test -- --run tests/DraftDayAnalyzer.test.jsx -t "hides duplicate player identities"` ✅

Closes #278