### PR TITLE
test: stabilize players router + Draft Day Analyzer full-file runs (#327)

### DIFF
--- a/backend/tests/test_players_router.py
+++ b/backend/tests/test_players_router.py
@@ -56,28 +56,28 @@ def test_top_free_agents_excludes_owned_and_sorts_by_projection(client):
             name=f"Owned Player {suffix}",
             position="WR",
             nfl_team="AAA",
-            projected_points=999999.0,
+            projected_points=9_000_000_003.0,
             adp=1.0,
         )
         top = models.Player(
             name=f"Top Player {suffix}",
             position="RB",
             nfl_team="BBB",
-            projected_points=999998.0,
+            projected_points=9_000_000_002.0,
             adp=12.0,
         )
         second = models.Player(
             name=f"Second Player {suffix}",
             position="WR",
             nfl_team="CCC",
-            projected_points=999997.0,
+            projected_points=9_000_000_001.0,
             adp=20.0,
         )
         third = models.Player(
             name=f"Third Player {suffix}",
             position="QB",
             nfl_team="DDD",
-            projected_points=999996.0,
+            projected_points=9_000_000_000.0,
             adp=30.0,
         )
         session.add_all([owned, top, second, third])
@@ -366,14 +366,14 @@ def test_top_free_agents_momentum_promotes_recent_waiver_target(client):
             name=f"Baseline Player {suffix}",
             position="WR",
             nfl_team="AAA",
-            projected_points=9100000.0,
+            projected_points=9_000_000_000_000.0,
             adp=60.0,
         )
         momentum = models.Player(
             name=f"Momentum Player {suffix}",
             position="WR",
             nfl_team="BBB",
-            projected_points=9099999.8,
+            projected_points=8_999_999_999_999.8,
             adp=60.0,
         )
         session.add_all([baseline, momentum])
@@ -433,30 +433,6 @@ def test_top_free_agents_momentum_promotes_recent_waiver_target(client):
         assert float(data[0].get("pickup_trend_score") or 0.0) > 0.0
     finally:
         client.cookies.clear()
-        cleanup = SessionLocal()
-        try:
-            if league_id is not None:
-                cleanup.query(models.User).filter(
-                    models.User.league_id == league_id
-                ).delete(synchronize_session=False)
-                cleanup.query(models.League).filter(
-                    models.League.id == league_id
-                ).delete(synchronize_session=False)
-                cleanup.commit()
-        finally:
-            cleanup.close()
-        cleanup = SessionLocal()
-        try:
-            if league_id is not None:
-                cleanup.query(models.User).filter(
-                    models.User.league_id == league_id
-                ).delete(synchronize_session=False)
-                cleanup.query(models.League).filter(
-                    models.League.id == league_id
-                ).delete(synchronize_session=False)
-                cleanup.commit()
-        finally:
-            cleanup.close()
         cleanup = SessionLocal()
         try:
             if created_txn_ids:

--- a/frontend/tests/DraftDayAnalyzer.test.jsx
+++ b/frontend/tests/DraftDayAnalyzer.test.jsx
@@ -41,9 +41,9 @@ const ownersPayload = [
 ];
 
 const playersPayload = [
-  { id: 101, name: 'Player A', nfl_team: 'BUF', position: 'WR' },
-  { id: 102, name: 'Player B', nfl_team: 'KC', position: 'WR' },
-  { id: 103, name: 'Player C', nfl_team: 'SF', position: 'RB' },
+  { id: 101, name: 'Player A', nfl_team: 'BUF', position: 'WR', espn_id: '101' },
+  { id: 102, name: 'Player B', nfl_team: 'KC', position: 'WR', espn_id: '102' },
+  { id: 103, name: 'Player C', nfl_team: 'SF', position: 'RB', espn_id: '103' },
 ];
 
 const duplicatePlayersPayload = [
@@ -72,6 +72,9 @@ const getVisiblePlayerRows = () =>
 
 const buildGetMock = () =>
   vi.fn((url, config = {}) => {
+    if (url === '/auth/me') {
+      return Promise.resolve({ data: { id: 1, is_commissioner: true } });
+    }
     if (url.startsWith('/leagues/owners')) {
       return Promise.resolve({ data: ownersPayload });
     }
@@ -102,7 +105,7 @@ const buildGetMock = () =>
     return Promise.resolve({ data: [] });
   });
 
-describe('DraftDayAnalyzer advisor actions', () => {
+describe.sequential('DraftDayAnalyzer advisor actions', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     localStorage.clear();
@@ -254,7 +257,7 @@ describe('DraftDayAnalyzer advisor actions', () => {
 
   test('hides duplicate player identities in analyzer list', async () => {
     const baseGet = buildGetMock();
-    apiClient.get = vi.fn((url, config = {}) => {
+    apiClient.get.mockImplementation((url, config = {}) => {
       if (url === '/players/') {
         return Promise.resolve({ data: duplicatePlayersPayload });
       }


### PR DESCRIPTION
## Summary
- stabilize backend players router full-file tests by fixing cleanup ordering and removing duplicated cleanup blocks
- harden backend test fixture scoring so assertions are resilient to pre-existing local fixture residue
- align Draft Day Analyzer frontend fixtures with current production filtering (skill players require external IDs)
- run Draft Day Analyzer tests sequentially and keep per-test mock overrides scoped via mockImplementation

## Validation
- `python3.13.exe -m pytest tests/test_players_router.py -q`
- `npm run test -- --run tests/DraftDayAnalyzer.test.jsx`

Closes #327