### PR TITLE
fix: include trade deadline in league settings response (#307)

### DIFF
--- a/backend/routers/league.py
+++ b/backend/routers/league.py
@@ -902,6 +902,7 @@ def get_league_settings(league_id: int, db: Session = Depends(get_db)):
         starting_waiver_budget=settings.starting_waiver_budget,
         waiver_system=settings.waiver_system,
         waiver_tiebreaker=settings.waiver_tiebreaker,
+        trade_deadline=settings.trade_deadline,
         draft_year=settings.draft_year,
         scoring_rules=[
             ScoringRuleSchema(

--- a/backend/tests/test_team_router.py
+++ b/backend/tests/test_team_router.py
@@ -504,6 +504,7 @@ def test_non_scoring_settings_update_propagates_to_lineup_submission(client, api
     settings_body = settings_res.json()
     assert int(settings_body.get('starting_slots', {}).get('ALLOW_PARTIAL_LINEUP', 0)) == 1
     assert settings_body.get('waiver_deadline') == 'Thu 10PM'
+    assert settings_body.get('trade_deadline') == 'Sat 3PM'
 
     allowed = client.post('/team/submit-lineup', json={'week': 1})
     assert allowed.status_code == 200


### PR DESCRIPTION
## Summary
- fix `/leagues/{league_id}/settings` to include `trade_deadline` in the response payload
- restore explicit integration assertion that updated trade deadline round-trips through settings reads
- keeps non-scoring propagation coverage aligned with #307 acceptance criteria

## Validation
- `python3.13.exe -m pytest tests/test_team_router.py -q`
- `python3.13.exe -m pytest tests/test_league_router.py -q`

Part of #307