### PR TITLE
test: finalize trade + waiver propagation coverage (#307)

### DIFF
--- a/backend/routers/trades.py
+++ b/backend/routers/trades.py
@@ -59,6 +59,25 @@ def propose_trade(
     if not current_user.league_id:
         raise HTTPException(status_code=400, detail="You must be in a league to propose a trade.")
 
+    settings = (
+        db.query(models.LeagueSettings)
+        .filter(models.LeagueSettings.league_id == current_user.league_id)
+        .first()
+    )
+    if settings and settings.trade_deadline:
+        raw_deadline = settings.trade_deadline.strip()
+        try:
+            parsed_deadline = datetime.fromisoformat(raw_deadline.replace("Z", "+00:00"))
+            now = datetime.now(parsed_deadline.tzinfo) if parsed_deadline.tzinfo else datetime.now()
+            if now > parsed_deadline:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Trade proposals are closed by commissioner rule (deadline: {settings.trade_deadline}).",
+                )
+        except ValueError:
+            # Legacy non-ISO deadline strings are tolerated and treated as advisory text only.
+            pass
+
     # verify future dollar availability
     offered = payload.offered_dollars or 0
     requested = payload.requested_dollars or 0

--- a/backend/tests/test_trade_router.py
+++ b/backend/tests/test_trade_router.py
@@ -143,3 +143,43 @@ def test_trade_proposal_validation():
     payload.note = None
     with pytest.raises(HTTPException):
         propose_trade(payload, db=db, current_user=cu)
+
+
+def test_trade_proposal_respects_commissioner_trade_deadline():
+    db = setup_db()
+    league = make_league(db)
+    db.add(
+        models.LeagueSettings(
+            league_id=league.id,
+            trade_deadline="2000-01-01T00:00:00Z",
+            future_draft_cap=25,
+        )
+    )
+    db.commit()
+
+    owner1 = make_user(db, league, "deadline-owner-1", budget=20)
+    owner2 = make_user(db, league, "deadline-owner-2", budget=20)
+    p1 = make_player(db, "Deadline A")
+    p2 = make_player(db, "Deadline B")
+    make_pick(db, owner1, p1)
+    make_pick(db, owner2, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+            self.future_draft_budget = user.future_draft_budget
+
+    payload = type("P", (), {})()
+    payload.to_user_id = owner2.id
+    payload.offered_player_id = p1.id
+    payload.requested_player_id = p2.id
+    payload.offered_dollars = 0
+    payload.requested_dollars = 0
+    payload.note = "after deadline"
+
+    with pytest.raises(HTTPException) as exc:
+        propose_trade(payload, db=db, current_user=CU(owner1))
+
+    assert exc.value.status_code == 400
+    assert "Trade proposals are closed" in str(exc.value.detail)

--- a/backend/tests/test_waiver_service.py
+++ b/backend/tests/test_waiver_service.py
@@ -99,3 +99,24 @@ def test_process_claim_rejects_when_ledger_balance_insufficient(db_session):
 
     assert exc.value.status_code == 400
     assert "Insufficient FAAB balance" in exc.value.detail
+
+
+def test_process_claim_rejects_after_commissioner_waiver_deadline(db_session):
+    league = make_league(db_session)
+    user = make_user(db_session, league, "waiver-owner-deadline")
+    target = make_player(db_session, "Deadline Target")
+
+    db_session.add(
+        models.LeagueSettings(
+            league_id=league.id,
+            waiver_deadline="2000-01-01T00:00:00Z",
+            roster_size=14,
+        )
+    )
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        process_claim(db_session, user=user, player_id=target.id, bid=0)
+
+    assert exc.value.status_code == 400
+    assert "Waiver claims are closed by commissioner rule" in str(exc.value.detail)


### PR DESCRIPTION
## Summary
- enforce commissioner `trade_deadline` in trade proposal flow (`/trades/propose`)
- add regression coverage that trade proposals are rejected after deadline
- add waiver boundary coverage that claims are rejected after commissioner `waiver_deadline`

## Validation
- `python3.13.exe -m pytest tests/test_trade_router.py -q`
- `python3.13.exe -m pytest tests/test_waiver_service.py -q`

Part of #307