### PR TITLE
fix(#367): retire CSV bootstrap path in load_ppl_history

### DIFF
--- a/backend/scripts/seed_draft_budgets.py
+++ b/backend/scripts/seed_draft_budgets.py
@@ -100,7 +100,9 @@ def seed(league_id: int = DEFAULT_LEAGUE_ID) -> None:
             print(
                 f"\nWARNING: {len(missing_owners)} owner IDs from the CSV are not in the users table "
                 f"and were skipped: {sorted(missing_owners)}\n"
-                "Run load_ppl_history.py first to populate the users table, then re-run this script."
+                "The users table must already be populated (the DB is the source of truth). "
+                "load_ppl_history.py is archival-only and requires an explicit opt-in; "
+                "do not run it unless rebuilding from scratch after a deliberate full-reset."
             )
         if inserted > 0:
             print(

--- a/backend/tests/test_load_ppl_history_guards.py
+++ b/backend/tests/test_load_ppl_history_guards.py
@@ -19,3 +19,31 @@ def test_validate_required_csv_sources_reports_missing_files(tmp_path):
         (tmp_path / name).write_text("header\n", encoding="utf-8")
 
     assert load_ppl_history.validate_required_csv_sources(str(tmp_path)) == []
+
+
+def test_main_refuses_without_env_flag(monkeypatch):
+    """main() must exit(1) when FFPI_ALLOW_LEGACY_CSV_BOOTSTRAP is not set."""
+    monkeypatch.delenv(load_ppl_history.CSV_BOOTSTRAP_ENV_FLAG, raising=False)
+    import pytest
+    with pytest.raises(SystemExit) as exc_info:
+        load_ppl_history.main(argv=[])
+    assert exc_info.value.code == 1
+
+
+def test_main_refuses_with_env_but_no_cli_flag(monkeypatch):
+    """main() must exit(1) when env is set but CLI flag is omitted."""
+    monkeypatch.setenv(load_ppl_history.CSV_BOOTSTRAP_ENV_FLAG, "1")
+    import pytest
+    with pytest.raises(SystemExit) as exc_info:
+        load_ppl_history.main(argv=[])
+    assert exc_info.value.code == 1
+
+
+def test_main_refuses_when_csv_sources_missing(monkeypatch, tmp_path):
+    """main() must exit(1) even with both flags if CSV source files are absent."""
+    monkeypatch.setenv(load_ppl_history.CSV_BOOTSTRAP_ENV_FLAG, "1")
+    monkeypatch.setattr(load_ppl_history, "DATA_DIR", str(tmp_path))
+    import pytest
+    with pytest.raises(SystemExit) as exc_info:
+        load_ppl_history.main(argv=["--allow-legacy-csv-bootstrap"])
+    assert exc_info.value.code == 1

--- a/backend/tests/test_load_ppl_history_guards.py
+++ b/backend/tests/test_load_ppl_history_guards.py
@@ -1,3 +1,5 @@
+import pytest
+
 from backend.scripts import load_ppl_history
 
 
@@ -24,7 +26,6 @@ def test_validate_required_csv_sources_reports_missing_files(tmp_path):
 def test_main_refuses_without_env_flag(monkeypatch):
     """main() must exit(1) when FFPI_ALLOW_LEGACY_CSV_BOOTSTRAP is not set."""
     monkeypatch.delenv(load_ppl_history.CSV_BOOTSTRAP_ENV_FLAG, raising=False)
-    import pytest
     with pytest.raises(SystemExit) as exc_info:
         load_ppl_history.main(argv=[])
     assert exc_info.value.code == 1
@@ -33,7 +34,6 @@ def test_main_refuses_without_env_flag(monkeypatch):
 def test_main_refuses_with_env_but_no_cli_flag(monkeypatch):
     """main() must exit(1) when env is set but CLI flag is omitted."""
     monkeypatch.setenv(load_ppl_history.CSV_BOOTSTRAP_ENV_FLAG, "1")
-    import pytest
     with pytest.raises(SystemExit) as exc_info:
         load_ppl_history.main(argv=[])
     assert exc_info.value.code == 1
@@ -43,7 +43,6 @@ def test_main_refuses_when_csv_sources_missing(monkeypatch, tmp_path):
     """main() must exit(1) even with both flags if CSV source files are absent."""
     monkeypatch.setenv(load_ppl_history.CSV_BOOTSTRAP_ENV_FLAG, "1")
     monkeypatch.setattr(load_ppl_history, "DATA_DIR", str(tmp_path))
-    import pytest
     with pytest.raises(SystemExit) as exc_info:
         load_ppl_history.main(argv=["--allow-legacy-csv-bootstrap"])
     assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
Closes #367

Completes the acceptance criteria for retiring the CSV bootstrap path in `load_ppl_history.py`.

## Changes

**Tests** (`backend/tests/test_load_ppl_history_guards.py`): Added 3 new `main()` refusal-path tests to prove the dual-signal gate works end-to-end:
- `test_main_refuses_without_env_flag` — no env set → `sys.exit(1)`
- `test_main_refuses_with_env_but_no_cli_flag` — env set but CLI flag omitted → `sys.exit(1)`
- `test_main_refuses_when_csv_sources_missing` — both signals present but CSV files absent → `sys.exit(1)`

All 5 guard tests now pass.

**Docs** (`backend/scripts/seed_draft_budgets.py`): Removed the directive to "run load_ppl_history.py first". Replaced with a statement that the DB is the source of truth and `load_ppl_history.py` is archival-only requiring explicit opt-in.

## Context
The dual safety gate (`FFPI_ALLOW_LEGACY_CSV_BOOTSTRAP=1` env + `--allow-legacy-csv-bootstrap` CLI flag) was already implemented in PR #377. This PR completes the issue by adding test coverage for the `main()` refusal paths and removing the stale doc reference that pointed users at the now-retired active bootstrap path.

## Acceptance Criteria
- [x] No active bootstrap path requires local CSV files
- [x] Script is hard-gated as archival-only (requires dual opt-in signal)
- [x] Tests reflect the new bootstrap source-of-truth (5 guard tests pass)
- [x] Docs updated — seed_draft_budgets.py no longer references load_ppl_history as active path

## Type of change
fix / tests