### PR TITLE
fix(#366,#368): Postgres-first MFL import + retire CSV CLI args

### DIFF
--- a/backend/manage.py
+++ b/backend/manage.py
@@ -644,8 +644,8 @@ def restore_mfl_archive(
 
 
 @cli.command("import-mfl-csv")
-@click.option("--source-mode", type=click.Choice(["db", "csv"]), default="db", show_default=True, help="Import source mode. Use db (recommended) to read from mfl_html_record_facts.")
-@click.option("--input-root", type=click.Path(file_okay=False, dir_okay=True, exists=True), default=None, help="Legacy CSV mode: extraction root folder (required when --source-mode=csv).")
+@click.option("--source-mode", type=click.Choice(["db", "csv"]), default="db", show_default=True, help="Import source mode. 'db' (default, recommended) reads from mfl_html_record_facts. 'csv' is LEGACY and requires --input-root.")
+@click.option("--input-root", type=click.Path(file_okay=False, dir_okay=True, exists=True), default=None, help="LEGACY CSV mode only: extraction root folder (required when --source-mode=csv). Not used in db mode.")
 @click.option("--source-league-id", type=str, default=None, help="Optional MFL league_id filter when --source-mode=db.")
 @click.option("--target-league-id", type=int, required=True, help="App league_id receiving imported rows.")
 @click.option("--start-year", type=int, required=True, help="First season year to import.")
@@ -697,8 +697,8 @@ def import_mfl_csv(
 
 
 @cli.command("bootstrap-mfl-franchise-users")
-@click.option("--franchises-csv", type=click.Path(file_okay=True, dir_okay=False, exists=True), default=None, help="Legacy mode: path to a staged franchises CSV (e.g. exports/history_staged_2003/franchises/2003.csv).")
-@click.option("--source-season", type=int, default=None, help="DB mode: season year to pull franchises from mfl_html_record_facts.")
+@click.option("--franchises-csv", type=click.Path(file_okay=True, dir_okay=False, exists=True), default=None, help="LEGACY: path to a staged franchises CSV. Prefer --source-season (DB mode) instead.")
+@click.option("--source-season", type=int, default=None, help="DB mode (recommended): season year to pull franchises from mfl_html_record_facts.")
 @click.option("--source-league-id", type=str, default=None, help="Optional MFL league_id filter when using --source-season.")
 @click.option("--target-league-id", type=int, required=True, help="App league_id to create stub users in.")
 @click.option("--apply", "apply_changes", is_flag=True, default=False, help="Write users to DB (default dry-run).")
@@ -711,9 +711,14 @@ def bootstrap_mfl_franchise_users(
 ):
     """Create locked stub user accounts for historical MFL franchises not yet in the league."""
     if franchises_csv and source_season is not None:
-        raise click.UsageError("Choose one input source: either --franchises-csv (legacy) or --source-season (DB mode), not both.")
+        raise click.UsageError("Choose one input source: either --franchises-csv (legacy CSV) or --source-season (DB mode), not both.")
     if not franchises_csv and source_season is None:
-        raise click.UsageError("Provide an input source: --source-season for DB mode (recommended) or --franchises-csv for legacy CSV mode.")
+        raise click.UsageError(
+            "--source-season is required. "
+            "Example: --source-season 2023 --target-league-id 60 "
+            "(reads from mfl_html_record_facts in the DB). "
+            "CSV mode is legacy only: use --franchises-csv to override."
+        )
 
     db = SessionLocal()
     try:

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -645,7 +645,7 @@ def restore_mfl_archive(
 
 @cli.command("import-mfl-csv")
 @click.option("--source-mode", type=click.Choice(["db", "csv"]), default="db", show_default=True, help="Import source mode. 'db' (default, recommended) reads from mfl_html_record_facts. 'csv' is LEGACY and requires --input-root.")
-@click.option("--input-root", type=click.Path(file_okay=False, dir_okay=True, exists=True), default=None, help="LEGACY CSV mode only: extraction root folder (required when --source-mode=csv). Not used in db mode.")
+@click.option("--input-root", type=click.Path(file_okay=False, dir_okay=True), default=None, help="LEGACY CSV mode only: extraction root folder (required when --source-mode=csv). Not used in db mode.")
 @click.option("--source-league-id", type=str, default=None, help="Optional MFL league_id filter when --source-mode=db.")
 @click.option("--target-league-id", type=int, required=True, help="App league_id receiving imported rows.")
 @click.option("--start-year", type=int, required=True, help="First season year to import.")

--- a/backend/scripts/import_mfl_csv.py
+++ b/backend/scripts/import_mfl_csv.py
@@ -337,7 +337,7 @@ def run_import_mfl_csv(
     start_year: int,
     end_year: int,
     dry_run: bool = True,
-    source_mode: str = "csv",
+    source_mode: str = "db",
     source_league_id: str | None = None,
 ) -> dict[str, Any]:
     seasons = list(range(start_year, end_year + 1))
@@ -352,6 +352,14 @@ def run_import_mfl_csv(
         raise ValueError("source_mode must be either 'csv' or 'db'")
     if source_mode == "csv" and not input_root:
         raise ValueError("input_root is required when source_mode='csv'")
+    if source_mode == "csv":
+        import sys as _sys
+        print(
+            "DeprecationWarning: source_mode='csv' is a legacy path. "
+            "Use source_mode='db' (the default) to read from mfl_html_record_facts. "
+            "CSV mode will be removed in a future release.",
+            file=_sys.stderr,
+        )
 
     root = Path(input_root) if input_root else None
     db = SessionLocal()

--- a/backend/scripts/import_mfl_csv.py
+++ b/backend/scripts/import_mfl_csv.py
@@ -353,12 +353,13 @@ def run_import_mfl_csv(
     if source_mode == "csv" and not input_root:
         raise ValueError("input_root is required when source_mode='csv'")
     if source_mode == "csv":
-        import sys as _sys
-        print(
-            "DeprecationWarning: source_mode='csv' is a legacy path. "
+        import warnings
+        warnings.warn(
+            "source_mode='csv' is a legacy path. "
             "Use source_mode='db' (the default) to read from mfl_html_record_facts. "
             "CSV mode will be removed in a future release.",
-            file=_sys.stderr,
+            DeprecationWarning,
+            stacklevel=2,
         )
 
     root = Path(input_root) if input_root else None

--- a/backend/scripts/ingest_data.py
+++ b/backend/scripts/ingest_data.py
@@ -7,8 +7,9 @@ DEPRECATED — superseded by load_ppl_history.py and the MFL migration pipeline.
     It is kept for historical reference only.  It is intentionally disabled:
     running it requires setting the environment variable
         FFPI_HARD_RESET=1
-    as a safety gate.  If you think you need this script, use
-    load_ppl_history.py for re-seeding PPL data instead.
+    as a safety gate.  load_ppl_history.py is also archival-only (requires
+    FFPI_ALLOW_LEGACY_CSV_BOOTSTRAP=1 + --allow-legacy-csv-bootstrap).
+    The DB is the source of truth; do not use these scripts for active data management.
 """
 import os
 import sys

--- a/backend/scripts/ingest_data.py
+++ b/backend/scripts/ingest_data.py
@@ -7,8 +7,8 @@ DEPRECATED — superseded by load_ppl_history.py and the MFL migration pipeline.
     It is kept for historical reference only.  It is intentionally disabled:
     running it requires setting the environment variable
         FFPI_HARD_RESET=1
-    as a safety gate.  load_ppl_history.py is also archival-only (requires
-    FFPI_ALLOW_LEGACY_CSV_BOOTSTRAP=1 + --allow-legacy-csv-bootstrap).
+    as a safety gate.  load_ppl_history.py is also archival-only (requires both
+    FFPI_ALLOW_LEGACY_CSV_BOOTSTRAP=1 env var and --allow-legacy-csv-bootstrap CLI flag).
     The DB is the source of truth; do not use these scripts for active data management.
 """
 import os

--- a/backend/tests/test_manage_import_mfl_csv_cli.py
+++ b/backend/tests/test_manage_import_mfl_csv_cli.py
@@ -77,3 +77,71 @@ def test_import_mfl_csv_cli_csv_mode_requires_input_root():
 
     assert result.exit_code != 0
     assert "--input-root is required when --source-mode=csv" in result.output
+
+
+def test_bootstrap_mfl_franchise_users_requires_source_season_or_csv():
+    """Invoking bootstrap without any source flag must error and direct user to --source-season."""
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "bootstrap-mfl-franchise-users",
+            "--target-league-id",
+            "60",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--source-season is required" in result.output
+
+
+def test_bootstrap_mfl_franchise_users_rejects_both_sources(tmp_path):
+    """Providing both --franchises-csv and --source-season must error."""
+    csv_file = tmp_path / "franchises.csv"
+    csv_file.write_text("season,league_id,franchise_id,franchise_name,owner_name\n")
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "bootstrap-mfl-franchise-users",
+            "--franchises-csv",
+            str(csv_file),
+            "--source-season",
+            "2023",
+            "--target-league-id",
+            "60",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Choose one input source" in result.output
+
+
+def test_import_mfl_csv_default_source_mode_is_db(monkeypatch):
+    """import-mfl-csv should default to db mode without requiring --source-mode."""
+    captured = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return {
+            "files_checked": 0, "files_missing": 0, "rows_validated": 0,
+            "rows_invalid": 0, "players_inserted": 0, "players_matched": 0,
+            "draft_picks_inserted": 0, "draft_picks_skipped": 0,
+            "matchups_inserted": 0, "matchups_skipped": 0,
+            "bye_matchups_skipped": 0, "skipped_missing_owner_map": 0,
+            "skipped_missing_player_map": 0,
+        }
+
+    monkeypatch.setattr(manage, "run_import_mfl_csv", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "import-mfl-csv",
+            "--target-league-id", "60",
+            "--start-year", "2022",
+            "--end-year", "2022",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured.get("source_mode") == "db"
+    assert captured.get("input_root") is None


### PR DESCRIPTION
## Summary
Closes #366
Closes #368

## Changes

### #366 — Replace `import_mfl_csv` with Postgres-first source contracts
- **`run_import_mfl_csv()` default `source_mode` changed from `'csv'` → `'db'`**: DB mode (reads from `mfl_html_record_facts`) is now the default for all programmatic callers, matching the CLI default that was already set correctly in `manage.py`.
- **DeprecationWarning on CSV mode**: When `source_mode='csv'` is explicitly passed, a stderr warning is emitted flagging it as a legacy path for removal in a future release.

### #368 — Remove required CSV args from MFL bootstrap/import CLI
- **`import-mfl-csv` help text**: `--source-mode=csv` and `--input-root` are now explicitly labeled as LEGACY in the CLI help.
- **`bootstrap-mfl-franchise-users`**: `--franchises-csv` help text updated to "LEGACY — prefer --source-season". Error message when neither source provided now directs users to `--source-season` as the primary path with a concrete example.
- **`ingest_data.py`**: Removed stale guidance directing users to `load_ppl_history.py` for re-seeding; both are now archival-only.

## Tests
Added 3 new CLI tests in `test_manage_import_mfl_csv_cli.py`:
- `test_bootstrap_mfl_franchise_users_requires_source_season_or_csv` — no flags → error with --source-season guidance
- `test_bootstrap_mfl_franchise_users_rejects_both_sources` — both flags → error
- `test_import_mfl_csv_default_source_mode_is_db` — no --source-mode flag → defaults to db

All 5 CLI tests pass.

## Acceptance Criteria
- [x] Active CLI flow does not require CSV file path
- [x] DB-backed bootstrap path is documented and tested
- [x] CSV-only args are optional/legacy and no longer default
- [x] Import command can run without CSV input-root when DB source is available
- [x] Regression tests cover DB-native import path
- [x] DeprecationWarning on csv mode usage

## Type of change
fix / tests