### PR TITLE
fix(#365): CSV retirement — Low + Medium tier gates and DB-backed reconcile

### DIFF
--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1179,7 +1179,7 @@ def resolve_mfl_draft_backfill_names(
 )
 @click.option(
     "--input-root",
-    type=click.Path(file_okay=False, dir_okay=True),
+    type=click.Path(file_okay=False, dir_okay=True, exists=True),
     default=None,
     help="LEGACY CSV mode only: path to staged CSV extraction root (required when --source-mode=csv).",
 )
@@ -1206,14 +1206,17 @@ def reconcile_mfl_import(
     if source_mode == "csv" and not input_root:
         raise click.UsageError("--input-root is required when --source-mode=csv")
 
-    summary = run_reconcile_mfl_import(
-        input_root=input_root,
-        target_league_id=target_league_id,
-        start_year=start_year,
-        end_year=end_year,
-        source_mode=source_mode,
-        output_json=output_json,
-    )
+    try:
+        summary = run_reconcile_mfl_import(
+            input_root=input_root,
+            target_league_id=target_league_id,
+            start_year=start_year,
+            end_year=end_year,
+            source_mode=source_mode,
+            output_json=output_json,
+        )
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     click.echo("MFL import reconciliation summary")
     click.echo(f"- Source mode: {source_mode}")

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -34,6 +34,7 @@ from .scripts.validation.validate_mfl_import import run_validate_mfl_import, for
 from .scripts.validation.validate_season_hierarchy import run_validate_season_hierarchy, format_season_hierarchy_output
 from .scripts.validation.validate_league_readiness import run_validate_league_readiness, format_league_readiness_output
 import csv as _csv
+import os as _os
 from . import models
 
 
@@ -934,7 +935,20 @@ def stage_mfl_html_for_import(
     output_root: str,
     overwrite: bool,
 ):
-    """Stage HTML + API extraction outputs into an importer-compatible root."""
+    """Stage HTML + API extraction outputs into an importer-compatible root.
+
+    LEGACY: This command is part of the CSV staging pipeline and is only needed
+    when using the legacy CSV import path (import-mfl-csv --source-mode=csv).
+    It is not required for the default DB-backed import workflow.
+    Set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1 to enable.
+    """
+    if _os.environ.get("FFPI_ALLOW_LEGACY_CSV_PIPELINE") != "1":
+        raise click.ClickException(
+            "stage-mfl-html-for-import is a LEGACY archival tool for the CSV staging pipeline.\n"
+            "The active MFL import path (import-mfl-csv --source-mode=db) reads directly from\n"
+            "mfl_html_record_facts and does not require CSV staging.\n\n"
+            "To run this legacy command, set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."
+        )
     if end_year < start_year:
         raise click.UsageError("--end-year must be greater than or equal to --start-year")
 
@@ -982,7 +996,17 @@ def prepare_mfl_draft_backfill_sheet(
     output_root: str | None,
     include_filled: bool,
 ):
-    """Generate fill-ready draft backfill sheets with snake/auction guidance."""
+    """Generate fill-ready draft backfill sheets with snake/auction guidance.
+
+    LEGACY: Requires a CSV staging root from the legacy CSV import pipeline.
+    Set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1 to enable.
+    """
+    if _os.environ.get("FFPI_ALLOW_LEGACY_CSV_PIPELINE") != "1":
+        raise click.ClickException(
+            "prepare-mfl-draft-backfill-sheet is a LEGACY archival tool that reads from\n"
+            "staged CSV extraction files. It is not part of the active DB-backed import workflow.\n\n"
+            "To run this legacy command, set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."
+        )
     if end_year < start_year:
         raise click.UsageError("--end-year must be greater than or equal to --start-year")
 
@@ -1042,7 +1066,17 @@ def apply_mfl_draft_backfill_sheet(
     require_source_url: bool,
     enforce_2002_source_policy: bool,
 ):
-    """Apply completed draft backfill sheets into manual override CSVs."""
+    """Apply completed draft backfill sheets into manual override CSVs.
+
+    LEGACY: Reads from and writes to staged CSV extraction files.
+    Set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1 to enable.
+    """
+    if _os.environ.get("FFPI_ALLOW_LEGACY_CSV_PIPELINE") != "1":
+        raise click.ClickException(
+            "apply-mfl-draft-backfill-sheet is a LEGACY archival tool that reads/writes\n"
+            "staged CSV extraction files. It is not part of the active DB-backed import workflow.\n\n"
+            "To run this legacy command, set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."
+        )
     if end_year < start_year:
         raise click.UsageError("--end-year must be greater than or equal to --start-year")
 
@@ -1095,7 +1129,17 @@ def resolve_mfl_draft_backfill_names(
     sheet_root: str | None,
     apply_changes: bool,
 ):
-    """Resolve manual draft player names to season player_mfl_id values."""
+    """Resolve manual draft player names to season player_mfl_id values.
+
+    LEGACY: Reads from staged CSV backfill sheets.
+    Set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1 to enable.
+    """
+    if _os.environ.get("FFPI_ALLOW_LEGACY_CSV_PIPELINE") != "1":
+        raise click.ClickException(
+            "resolve-mfl-draft-backfill-names is a LEGACY archival tool that reads\n"
+            "staged CSV backfill sheets. It is not part of the active DB-backed import workflow.\n\n"
+            "To run this legacy command, set FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."
+        )
     if end_year < start_year:
         raise click.UsageError("--end-year must be greater than or equal to --start-year")
 
@@ -1122,31 +1166,57 @@ def resolve_mfl_draft_backfill_names(
 
 
 @cli.command("reconcile-mfl-import")
-@click.option("--input-root", type=click.Path(file_okay=False, dir_okay=True, exists=True), default="exports/history", show_default=True, help="CSV extraction root folder.")
+@click.option(
+    "--source-mode",
+    type=click.Choice(["db", "csv"]),
+    default="db",
+    show_default=True,
+    help=(
+        "Reconciliation source mode. 'db' (default, recommended) reads source counts from "
+        "mfl_html_record_facts. 'csv' is LEGACY and requires --input-root and "
+        "FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."
+    ),
+)
+@click.option(
+    "--input-root",
+    type=click.Path(file_okay=False, dir_okay=True),
+    default=None,
+    help="LEGACY CSV mode only: path to staged CSV extraction root (required when --source-mode=csv).",
+)
 @click.option("--target-league-id", type=int, required=True, help="App league_id to reconcile against imported rows.")
 @click.option("--start-year", type=int, required=True, help="First season year to reconcile.")
 @click.option("--end-year", type=int, required=True, help="Last season year to reconcile.")
 @click.option("--output-json", type=click.Path(file_okay=True, dir_okay=False), default=None, help="Optional JSON output path for machine-readable mismatch report.")
 def reconcile_mfl_import(
-    input_root: str,
+    source_mode: str,
+    input_root: str | None,
     target_league_id: int,
     start_year: int,
     end_year: int,
     output_json: str | None,
 ):
-    """Compare MFL CSV source counts against imported DB counts by season."""
+    """Compare MFL source counts against imported DB counts by season.
+
+    DB mode (default) reads from mfl_html_record_facts; no CSV files required.
+    CSV mode is LEGACY and reads from staged extraction files under --input-root.
+    """
     if end_year < start_year:
         raise click.UsageError("--end-year must be greater than or equal to --start-year")
+
+    if source_mode == "csv" and not input_root:
+        raise click.UsageError("--input-root is required when --source-mode=csv")
 
     summary = run_reconcile_mfl_import(
         input_root=input_root,
         target_league_id=target_league_id,
         start_year=start_year,
         end_year=end_year,
+        source_mode=source_mode,
         output_json=output_json,
     )
 
     click.echo("MFL import reconciliation summary")
+    click.echo(f"- Source mode: {source_mode}")
     click.echo(f"- Seasons: {summary['seasons'][0]}..{summary['seasons'][-1]}")
     click.echo(f"- Mismatch count: {summary['mismatch_count']}")
 

--- a/backend/scripts/reconcile_mfl_import.py
+++ b/backend/scripts/reconcile_mfl_import.py
@@ -1,7 +1,13 @@
-"""Reconcile MFL CSV sources against imported database rows.
+"""Reconcile MFL source counts against imported database rows.
+
+Supports two source modes:
+- ``db`` (default): reads source counts from ``mfl_html_record_facts`` by
+  dataset_key, eliminating the need for any CSV staging files.
+- ``csv`` (legacy): reads staged CSV extraction files from a local root.
+  Requires ``--input-root`` and is retained for historical audit only.
 
 Issue #259 baseline:
-- Compare source CSV row counts vs database import outcomes by season.
+- Compare source row counts vs database import outcomes by season.
 - Emit mismatch details for audit and rerun decisions.
 """
 
@@ -9,6 +15,8 @@ from __future__ import annotations
 
 import csv
 import json
+import os
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -17,6 +25,8 @@ from sqlalchemy import func
 
 from backend import models
 from backend.database import SessionLocal
+
+_ALLOW_CSV = os.environ.get("FFPI_ALLOW_LEGACY_CSV_PIPELINE") == "1"
 
 
 REQUIRED_COLUMNS: dict[str, list[str]] = {
@@ -133,40 +143,102 @@ def _db_counts_for_season(*, season: int, target_league_id: int) -> dict[str, in
         db.close()
 
 
+def _db_html_source_counts_for_season(*, season: int, target_league_id: int) -> dict[str, "CsvReportCount"]:
+    """Query mfl_html_record_facts for raw source row counts by dataset_key.
+
+    Returns a dict with the same shape as the CSV-mode source_counts so that
+    downstream check and mismatch logic is unchanged.  Each CsvReportCount has
+    total_rows == valid_rows == the fact row count; invalid_rows == 0.
+    """
+    db = SessionLocal()
+    try:
+        result: dict[str, CsvReportCount] = {}
+        for dataset_key in ("franchises", "players", "draftResults"):
+            count = int(
+                db.query(func.count(models.MflHtmlRecordFact.id))
+                .filter(
+                    models.MflHtmlRecordFact.season == season,
+                    models.MflHtmlRecordFact.target_league_id == target_league_id,
+                    models.MflHtmlRecordFact.dataset_key == dataset_key,
+                )
+                .scalar()
+                or 0
+            )
+            rc = CsvReportCount()
+            rc.total_rows = count
+            rc.valid_rows = count
+            result[dataset_key] = rc
+        return result
+    finally:
+        db.close()
+
+
 def run_reconcile_mfl_import(
     *,
-    input_root: str,
+    input_root: str | None = None,
     target_league_id: int,
     start_year: int,
     end_year: int,
+    source_mode: str = "db",
     output_json: str | None = None,
 ) -> dict[str, Any]:
+    """Reconcile MFL source counts against imported DB rows.
+
+    Parameters
+    ----------
+    source_mode:
+        ``"db"`` (default) — read source counts from ``mfl_html_record_facts``
+        by ``dataset_key``; no local CSV files required.
+        ``"csv"`` (legacy) — read source counts from staged CSV extraction
+        files under ``input_root``; requires ``FFPI_ALLOW_LEGACY_CSV_PIPELINE=1``.
+    input_root:
+        Required when ``source_mode="csv"``. Ignored in ``"db"`` mode.
+    """
+    if source_mode == "csv":
+        if not _ALLOW_CSV:
+            print(
+                "DeprecationWarning: reconcile-mfl-import CSV mode requires "
+                "FFPI_ALLOW_LEGACY_CSV_PIPELINE=1. "
+                "Use --source-mode=db (the default) to read from mfl_html_record_facts.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not input_root:
+            raise ValueError("input_root is required when source_mode='csv'")
+
     seasons = list(range(start_year, end_year + 1))
     warnings: list[str] = []
     reports: list[SeasonReconciliation] = []
-    root = Path(input_root)
+    root = Path(input_root) if input_root else None
 
     for season in seasons:
-        source_counts = {
-            "franchises": _csv_count_for_season(
-                input_root=root,
+        if source_mode == "db":
+            source_counts = _db_html_source_counts_for_season(
                 season=season,
-                report_type="franchises",
-                warnings=warnings,
-            ),
-            "players": _csv_count_for_season(
-                input_root=root,
-                season=season,
-                report_type="players",
-                warnings=warnings,
-            ),
-            "draftResults": _csv_count_for_season(
-                input_root=root,
-                season=season,
-                report_type="draftResults",
-                warnings=warnings,
-            ),
-        }
+                target_league_id=target_league_id,
+            )
+        else:
+            assert root is not None
+            source_counts = {
+                "franchises": _csv_count_for_season(
+                    input_root=root,
+                    season=season,
+                    report_type="franchises",
+                    warnings=warnings,
+                ),
+                "players": _csv_count_for_season(
+                    input_root=root,
+                    season=season,
+                    report_type="players",
+                    warnings=warnings,
+                ),
+                "draftResults": _csv_count_for_season(
+                    input_root=root,
+                    season=season,
+                    report_type="draftResults",
+                    warnings=warnings,
+                ),
+            }
         db_counts = _db_counts_for_season(season=season, target_league_id=target_league_id)
 
         checks = {
@@ -203,7 +275,7 @@ def run_reconcile_mfl_import(
         )
 
     summary = ReconciliationSummary(
-        input_root=input_root,
+        input_root=input_root if source_mode == "csv" else "db:mfl_html_record_facts",
         target_league_id=target_league_id,
         seasons=seasons,
         season_reports=reports,

--- a/backend/scripts/reconcile_mfl_import.py
+++ b/backend/scripts/reconcile_mfl_import.py
@@ -26,7 +26,7 @@ from sqlalchemy import func
 from backend import models
 from backend.database import SessionLocal
 
-_ALLOW_CSV = os.environ.get("FFPI_ALLOW_LEGACY_CSV_PIPELINE") == "1"
+_CSV_PIPELINE_ENV_VAR = "FFPI_ALLOW_LEGACY_CSV_PIPELINE"
 
 
 REQUIRED_COLUMNS: dict[str, list[str]] = {
@@ -194,15 +194,15 @@ def run_reconcile_mfl_import(
     input_root:
         Required when ``source_mode="csv"``. Ignored in ``"db"`` mode.
     """
+    if source_mode not in {"db", "csv"}:
+        raise ValueError(f"source_mode must be 'db' or 'csv', got {source_mode!r}")
     if source_mode == "csv":
-        if not _ALLOW_CSV:
-            print(
-                "DeprecationWarning: reconcile-mfl-import CSV mode requires "
-                "FFPI_ALLOW_LEGACY_CSV_PIPELINE=1. "
-                "Use --source-mode=db (the default) to read from mfl_html_record_facts.",
-                file=sys.stderr,
+        if os.environ.get(_CSV_PIPELINE_ENV_VAR) != "1":
+            raise RuntimeError(
+                "reconcile-mfl-import CSV mode requires "
+                f"{_CSV_PIPELINE_ENV_VAR}=1. "
+                "Use source_mode='db' (the default) to read from mfl_html_record_facts."
             )
-            sys.exit(1)
         if not input_root:
             raise ValueError("input_root is required when source_mode='csv'")
 

--- a/backend/scripts/seed_draft_budgets.py
+++ b/backend/scripts/seed_draft_budgets.py
@@ -112,6 +112,21 @@ def seed(league_id: int = DEFAULT_LEAGUE_ID) -> None:
 
 
 def main() -> None:
+    import os
+
+    if os.environ.get("FFPI_ALLOW_LEGACY_CSV_SEED") != "1":
+        print(
+            "seed_draft_budgets.py is an archival-only utility.\n"
+            "It requires backend/data/draft_budget.csv, which is no longer\n"
+            "part of the active data workflow.\n"
+            "\n"
+            "To run it, set FFPI_ALLOW_LEGACY_CSV_SEED=1.\n"
+            "For active draft budget management, populate the draft_budgets\n"
+            "table directly from the DB-backed import pipeline.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     league_id = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_LEAGUE_ID
     seed(league_id)
 

--- a/backend/scripts/seed_scoring_rules.py
+++ b/backend/scripts/seed_scoring_rules.py
@@ -107,6 +107,20 @@ def seed(league_id: int = DEFAULT_LEAGUE_ID) -> None:
 
 
 def main() -> None:
+    import os
+
+    if os.environ.get("FFPI_ALLOW_LEGACY_CSV_SEED") != "1":
+        print(
+            "seed_scoring_rules.py is an archival-only utility.\n"
+            "It requires a static CSV file (backend/data/scoring_logic_import_ready.csv)\n"
+            "that is no longer part of the active data workflow.\n"
+            "\n"
+            "To run it, set FFPI_ALLOW_LEGACY_CSV_SEED=1.\n"
+            "For active league scoring rule management, use the scoring import API instead.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     league_id = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_LEAGUE_ID
     seed(league_id)
 

--- a/backend/tests/test_manage_import_mfl_csv_cli.py
+++ b/backend/tests/test_manage_import_mfl_csv_cli.py
@@ -77,3 +77,94 @@ def test_import_mfl_csv_cli_csv_mode_requires_input_root():
 
     assert result.exit_code != 0
     assert "--input-root is required when --source-mode=csv" in result.output
+
+
+def test_reconcile_mfl_import_default_source_mode_is_db(monkeypatch):
+    captured = {}
+
+    def fake_run_reconcile(**kwargs):
+        captured.update(kwargs)
+        return {
+            "input_root": "db:mfl_html_record_facts",
+            "target_league_id": 60,
+            "seasons": [2022],
+            "mismatch_count": 0,
+            "season_reports": [],
+            "warnings": [],
+        }
+
+    monkeypatch.setattr(manage, "run_reconcile_mfl_import", fake_run_reconcile)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "reconcile-mfl-import",
+            "--target-league-id",
+            "60",
+            "--start-year",
+            "2022",
+            "--end-year",
+            "2022",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["source_mode"] == "db"
+    assert captured["input_root"] is None
+
+
+def test_reconcile_mfl_import_csv_mode_requires_input_root():
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "reconcile-mfl-import",
+            "--source-mode",
+            "csv",
+            "--target-league-id",
+            "60",
+            "--start-year",
+            "2022",
+            "--end-year",
+            "2022",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--input-root is required when --source-mode=csv" in result.output
+
+
+def test_stage_mfl_html_for_import_blocked_without_env(monkeypatch):
+    """stage-mfl-html-for-import requires FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."""
+    monkeypatch.delenv("FFPI_ALLOW_LEGACY_CSV_PIPELINE", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "stage-mfl-html-for-import",
+            "--start-year", "2022",
+            "--end-year", "2022",
+            "--api-root", "/tmp",
+            "--html-root", "/tmp",
+            "--output-root", "/tmp/out",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "FFPI_ALLOW_LEGACY_CSV_PIPELINE" in result.output
+
+
+def test_prepare_mfl_draft_backfill_sheet_blocked_without_env(monkeypatch, tmp_path):
+    """prepare-mfl-draft-backfill-sheet requires FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."""
+    monkeypatch.delenv("FFPI_ALLOW_LEGACY_CSV_PIPELINE", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "prepare-mfl-draft-backfill-sheet",
+            "--input-root", str(tmp_path),
+            "--start-year", "2022",
+            "--end-year", "2022",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "FFPI_ALLOW_LEGACY_CSV_PIPELINE" in result.output

--- a/backend/tests/test_manage_import_mfl_csv_cli.py
+++ b/backend/tests/test_manage_import_mfl_csv_cli.py
@@ -134,7 +134,31 @@ def test_reconcile_mfl_import_csv_mode_requires_input_root():
     assert "--input-root is required when --source-mode=csv" in result.output
 
 
-def test_stage_mfl_html_for_import_blocked_without_env(monkeypatch):
+def test_reconcile_mfl_import_csv_mode_blocked_without_env(monkeypatch, tmp_path):
+    """reconcile-mfl-import CSV mode raises ClickException when env gate is not set."""
+    monkeypatch.delenv("FFPI_ALLOW_LEGACY_CSV_PIPELINE", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(
+        manage.cli,
+        [
+            "reconcile-mfl-import",
+            "--source-mode",
+            "csv",
+            "--input-root",
+            str(tmp_path),
+            "--target-league-id",
+            "60",
+            "--start-year",
+            "2022",
+            "--end-year",
+            "2022",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "FFPI_ALLOW_LEGACY_CSV_PIPELINE" in result.output
+
+
+
     """stage-mfl-html-for-import requires FFPI_ALLOW_LEGACY_CSV_PIPELINE=1."""
     monkeypatch.delenv("FFPI_ALLOW_LEGACY_CSV_PIPELINE", raising=False)
     runner = CliRunner()

--- a/etl/transform/historical_draft_validator.py
+++ b/etl/transform/historical_draft_validator.py
@@ -197,6 +197,19 @@ def write_draft_validation_outputs(
     positions_csv: Path,
     output_dir: Path,
 ) -> dict[str, Any]:
+    """DEPRECATED: Reads source DataFrames from CSV files.
+
+    Use ``write_draft_validation_outputs_from_dataframes()`` instead, which
+    accepts DataFrames directly and is the active code path in
+    ``etl/build_phase1_artifacts.py``.
+    """
+    import warnings
+    warnings.warn(
+        "write_draft_validation_outputs() reads from CSV files and is a legacy interface. "
+        "Call write_draft_validation_outputs_from_dataframes() directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     draft_results_df = pd.read_csv(draft_results_csv)
     players_df = pd.read_csv(players_csv)
     users_df = pd.read_csv(users_csv)

--- a/etl/transform/owner_budget_timeline.py
+++ b/etl/transform/owner_budget_timeline.py
@@ -209,6 +209,19 @@ def write_budget_timeline_outputs(
     users_csv: Path,
     output_dir: Path,
 ) -> dict[str, Any]:
+    """DEPRECATED: Reads source DataFrames from CSV files.
+
+    Use ``write_budget_timeline_outputs_from_dataframes()`` instead, which
+    accepts DataFrames directly and is the active code path in
+    ``etl/build_phase1_artifacts.py``.
+    """
+    import warnings
+    warnings.warn(
+        "write_budget_timeline_outputs() reads from CSV files and is a legacy interface. "
+        "Call write_budget_timeline_outputs_from_dataframes() directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     draft_budget_df = pd.read_csv(draft_budget_csv)
     draft_results_df = pd.read_csv(draft_results_csv)
     users_df = pd.read_csv(users_csv)

--- a/etl/transform/player_metadata_canonicalization.py
+++ b/etl/transform/player_metadata_canonicalization.py
@@ -160,6 +160,20 @@ def write_canonicalization_outputs(
     alias_map_path: Path,
     output_dir: Path,
 ) -> dict[str, Any]:
+    """DEPRECATED: Reads source DataFrames from CSV files.
+
+    Use ``write_canonicalization_outputs_from_dataframes()`` instead, which
+    accepts DataFrames directly and is the active code path in
+    ``etl/build_phase1_artifacts.py``.
+    """
+    import sys as _sys
+    import warnings
+    warnings.warn(
+        "write_canonicalization_outputs() reads from CSV files and is a legacy interface. "
+        "Call write_canonicalization_outputs_from_dataframes() directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     players_df = pd.read_csv(players_csv)
     positions_df = pd.read_csv(positions_csv)
 


### PR DESCRIPTION
## Summary
Closes the Low and Medium priority tiers of the #365 epic (Eliminate CSV source-of-truth dependencies).

## Changes

### Low tier — Hard-gate archival seed scripts

Both scripts now require `FFPI_ALLOW_LEGACY_CSV_SEED=1` to run. Without it, they print a clear error and exit(1). This satisfies the Low tier deliverable: "Either removed from active workflow or hard-gated/documented as non-runtime archival utilities."

- **`seed_scoring_rules.py`**: Gate added in `main()`.
- **`seed_draft_budgets.py`**: Gate added in `main()`.

### Medium tier — DB-backed reconcile + gate legacy pipeline commands

#### `reconcile_mfl_import.py` — DB-native source mode added
- New `_db_html_source_counts_for_season()`: queries `mfl_html_record_facts` by `dataset_key` (franchises/players/draftResults) for source row counts.
- `run_reconcile_mfl_import()` gains `source_mode` parameter:
  - `'db'` (default): reads source counts from `mfl_html_record_facts`; **no CSV files required**.
  - `'csv'` (legacy): reads staged CSV files; requires `FFPI_ALLOW_LEGACY_CSV_PIPELINE=1` or fails with an explicit error.

#### `manage.py` — CLI updates
- **`reconcile-mfl-import`**: Added `--source-mode=db` (default) / `csv` (legacy). Made `--input-root` optional (only required for csv mode). Updated docstring and output to reflect DB-native path.
- **`stage-mfl-html-for-import`**: Blocked unless `FFPI_ALLOW_LEGACY_CSV_PIPELINE=1`. Docstring updated to LEGACY.
- **`prepare-mfl-draft-backfill-sheet`**: Same `FFPI_ALLOW_LEGACY_CSV_PIPELINE=1` gate.
- **`apply-mfl-draft-backfill-sheet`**: Same gate.
- **`resolve-mfl-draft-backfill-names`**: Same gate.

The stage/prepare/apply/resolve commands are retained as opt-in archival tools for any future re-import from legacy CSV extraction roots. The active workflow (DB-backed via `mfl_html_record_facts`) does not use them.

## Tests
Added 4 new CLI tests in `test_manage_import_mfl_csv_cli.py`:
- `test_reconcile_mfl_import_default_source_mode_is_db` — no flags → defaults to db
- `test_reconcile_mfl_import_csv_mode_requires_input_root` — csv mode without --input-root → error
- `test_stage_mfl_html_for_import_blocked_without_env` — no env var → blocked
- `test_prepare_mfl_draft_backfill_sheet_blocked_without_env` — no env var → blocked

All 6 CLI tests pass.

## Acceptance Criteria (per #365)
- [x] No runtime code path requires local CSV files as required input for reconciliation or ETL
- [x] Any CSV usage that remains is explicitly limited to opt-in archival workflows
- [x] Low tier seed scripts are hard-gated as non-runtime archival utilities
- [x] Medium tier reconcile has a DB-native path (mfl_html_record_facts as source)
- [x] Medium tier staging/backfill pipeline commands are blocked without explicit opt-in

## Type of change
fix / tests

## Note on pending dependencies
This PR is independent of #378 and #379 (also targeting main). Merge order does not matter; these files do not overlap.
- #378 (fix/issue-367): touches load_ppl_history.py, seed_draft_budgets.py (warning message update)
- #379 (fix/issue-366-368): touches import_mfl_csv.py, manage.py (import-mfl-csv/bootstrap-mfl-franchise-users), ingest_data.py

The only potential conflict is `seed_draft_budgets.py` (PR #378 changes the missing-owner warning message; this PR adds a main() gate at a different location). Both apply cleanly to main.