### PR TITLE
test: Trade + TradeAsset + TradeEvent relationship tests (#345)

### DIFF
--- a/backend/tests/test_trade_models.py
+++ b/backend/tests/test_trade_models.py
@@ -102,3 +102,103 @@ def test_trade_and_trade_assets_persist_with_relationships():
     assert by_type["PLAYER"].player_id == player.id
     assert by_type["DRAFT_PICK"].draft_pick_id == pick.id
     assert float(by_type["DRAFT_DOLLARS"].amount or 0) == 15.0
+
+
+def test_trade_events_persist_with_relationship():
+    db = setup_db()
+    league = make_league(db, name="EventLeague")
+    team_a = make_user(db, league, "event-team-a")
+    team_b = make_user(db, league, "event-team-b")
+
+    trade = models.Trade(
+        league_id=league.id,
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        created_by_user_id=team_a.id,
+        status="PENDING",
+    )
+    db.add(trade)
+    db.commit()
+    db.refresh(trade)
+
+    events = [
+        models.TradeEvent(
+            trade_id=trade.id,
+            event_type="SUBMITTED",
+            actor_user_id=team_a.id,
+            comment="Trade submitted by team A",
+        ),
+        models.TradeEvent(
+            trade_id=trade.id,
+            event_type="APPROVED",
+            actor_user_id=None,
+            comment="Commissioner approved",
+            metadata_json={"auto_approved": False},
+        ),
+    ]
+    db.add_all(events)
+    db.commit()
+
+    saved_trade = db.get(models.Trade, trade.id)
+    assert len(saved_trade.events) == 2
+
+    by_type = {e.event_type: e for e in saved_trade.events}
+    assert by_type["SUBMITTED"].actor_user_id == team_a.id
+    assert by_type["SUBMITTED"].comment == "Trade submitted by team A"
+    assert by_type["APPROVED"].metadata_json == {"auto_approved": False}
+    assert by_type["APPROVED"].actor_user_id is None
+
+
+def test_trade_status_lifecycle():
+    """Trade moves through PENDING -> APPROVED lifecycle with timestamps."""
+    from datetime import datetime, timezone
+
+    db = setup_db()
+    league = make_league(db, name="LifecycleLeague")
+    team_a = make_user(db, league, "lc-team-a")
+    team_b = make_user(db, league, "lc-team-b")
+
+    trade = models.Trade(
+        league_id=league.id,
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        status="PENDING",
+    )
+    db.add(trade)
+    db.commit()
+    db.refresh(trade)
+
+    assert trade.status == "PENDING"
+    assert trade.approved_at is None
+    assert trade.rejected_at is None
+
+    now = datetime.now(timezone.utc)
+    trade.status = "APPROVED"
+    trade.approved_at = now
+    trade.commissioner_comments = "Looks fair"
+    db.commit()
+    db.refresh(trade)
+
+    assert trade.status == "APPROVED"
+    assert trade.approved_at is not None
+    assert trade.commissioner_comments == "Looks fair"
+
+    # Verify REJECTED path on a second trade
+    trade2 = models.Trade(
+        league_id=league.id,
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        status="PENDING",
+    )
+    db.add(trade2)
+    db.commit()
+    db.refresh(trade2)
+
+    trade2.status = "REJECTED"
+    trade2.rejected_at = datetime.now(timezone.utc)
+    trade2.commissioner_comments = "Unbalanced value"
+    db.commit()
+    db.refresh(trade2)
+
+    assert trade2.status == "REJECTED"
+    assert trade2.rejected_at is not None


### PR DESCRIPTION
Closes #345

## Summary
The `Trade`, `TradeAsset`, and `TradeEvent` ORM models and Alembic migrations were already implemented in PR #359. This PR completes the acceptance criteria for #345 by adding the missing relationship tests.

## What was already in main
- `Trade` model with full status lifecycle fields (`PENDING`/`APPROVED`/`REJECTED`), timestamps, and FK relationships to `League`, `User` (team_a, team_b, created_by)
- `TradeAsset` model supporting `PLAYER`, `DRAFT_PICK`, and `DRAFT_DOLLARS` asset types with `asset_side` (A/B)
- `TradeEvent` audit timeline model with `event_type`, actor, comment, and JSON metadata
- Alembic migrations `20260330_01` and `20260330_02`
- Composite indexes on all hot query paths

## Added in this PR
Two new tests in `backend/tests/test_trade_models.py`:

- `test_trade_events_persist_with_relationship` — verifies TradeEvent rows link back to Trade via `saved_trade.events`, event_type and metadata_json round-trip correctly, and null actor_user_id is valid
- `test_trade_status_lifecycle` — verifies Trade moves through PENDING → APPROVED with `approved_at` timestamp and commissioner_comments; and PENDING → REJECTED with `rejected_at`

## Acceptance Criteria
- [x] Trade + TradeAsset models created (in main via #359)
- [x] Migration applies cleanly (20260330_01, 20260330_02 in main)
- [x] Relationship tests pass (3/3 passing)