### PR TITLE
test: Trade validation service comprehensive test coverage (#346)

### DIFF
--- a/backend/tests/test_trade_validation_service.py
+++ b/backend/tests/test_trade_validation_service.py
@@ -141,3 +141,398 @@ def test_validate_trade_request_aggregates_errors_from_multiple_checks():
     assert "assets_from_b" in report.errors
     assert "trade_window" in report.errors
     assert "assets_from_a" in report.errors or "assets_from_a[2]" in report.errors
+
+
+# ==== HAPPY PATH TESTS ====
+
+
+def test_validate_multi_asset_trade_accepts_valid_players_and_picks():
+    report = validate_multi_asset_trade(
+        assets_from_a=[
+            TradeAssetInput(asset_type="PLAYER", player_id=1),
+            TradeAssetInput(asset_type="PLAYER", player_id=2),
+        ],
+        assets_from_b=[
+            TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=100),
+        ],
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_multi_asset_trade_accepts_mixed_asset_types():
+    report = validate_multi_asset_trade(
+        assets_from_a=[
+            TradeAssetInput(asset_type="PLAYER", player_id=1),
+            TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=25),
+        ],
+        assets_from_b=[
+            TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=50),
+            TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=50),
+        ],
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_trade_window_accepts_open_window():
+    now = datetime.now(UTC)
+    report = validate_trade_window(
+        trade_start_at=now - timedelta(days=1),
+        trade_end_at=now + timedelta(days=10),
+        allow_playoff_trades=True,
+        is_playoff=False,
+        now=now,
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_trade_window_accepts_playoff_trades_when_enabled():
+    now = datetime.now(UTC)
+    report = validate_trade_window(
+        trade_start_at=now - timedelta(days=1),
+        trade_end_at=now + timedelta(days=10),
+        allow_playoff_trades=True,
+        is_playoff=True,
+        now=now,
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_trade_window_accepts_no_window_restrictions():
+    report = validate_trade_window(
+        trade_start_at=None,
+        trade_end_at=None,
+        allow_playoff_trades=True,
+        is_playoff=False,
+        now=None,
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_draft_pick_ownership_accepts_owned_picks_within_limits():
+    report = validate_draft_pick_ownership(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[
+            TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=10, season_year=2026),
+        ],
+        assets_from_b=[
+            TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=50, season_year=2027),
+        ],
+        owned_pick_ids_by_team={1: {10, 11, 12}, 2: {50, 51}},
+        max_future_year_offset=2,
+        current_season=2026,
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_draft_capital_accepts_within_available_balance():
+    report = validate_draft_capital(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=15)],
+        assets_from_b=[TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=10)],
+        available_draft_dollars={1: 50, 2: 40},
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_draft_capital_accepts_zero_dollars_when_other_assets_present():
+    report = validate_draft_capital(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[TradeAssetInput(asset_type="PLAYER", player_id=1)],
+        assets_from_b=[TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=100)],
+        available_draft_dollars={1: 50, 2: 40},
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_position_suppression_accepts_non_suppressed_positions():
+    report = validate_position_suppression(
+        assets_from_a=[
+            TradeAssetInput(asset_type="PLAYER", player_id=1, position="RB"),
+            TradeAssetInput(asset_type="PLAYER", player_id=2, position="WR"),
+        ],
+        assets_from_b=[
+            TradeAssetInput(asset_type="PLAYER", player_id=3, position="QB"),
+        ],
+        suppressed_positions={"K", "DEF"},
+        player_positions_by_id={},
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_position_suppression_allows_non_player_assets():
+    report = validate_position_suppression(
+        assets_from_a=[
+            TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=1),
+            TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=25),
+        ],
+        assets_from_b=[],
+        suppressed_positions={"K", "DEF"},
+        player_positions_by_id={},
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_roster_limits_accepts_valid_trade():
+    report = validate_roster_limits(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[TradeAssetInput(asset_type="PLAYER", player_id=1)],
+        assets_from_b=[TradeAssetInput(asset_type="PLAYER", player_id=2)],
+        roster_sizes={1: 12, 2: 12},
+        max_roster_size=15,
+        min_roster_size=8,
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_roster_limits_accepts_boundary_sizes():
+    report = validate_roster_limits(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[
+            TradeAssetInput(asset_type="PLAYER", player_id=1),
+            TradeAssetInput(asset_type="PLAYER", player_id=2),
+            TradeAssetInput(asset_type="PLAYER", player_id=3),
+        ],
+        assets_from_b=[TradeAssetInput(asset_type="PLAYER", player_id=4)],
+        roster_sizes={1: 15, 2: 8},
+        max_roster_size=15,
+        min_roster_size=8,
+    )
+
+    assert report.valid
+    assert not report.errors
+
+
+def test_validate_trade_request_accepts_valid_full_trade():
+    now = datetime.now(UTC)
+    context = TradeValidationContext(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[
+            TradeAssetInput(asset_type="PLAYER", player_id=1, position="RB"),
+            TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=100, season_year=2027),
+            TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=20),
+        ],
+        assets_from_b=[
+            TradeAssetInput(asset_type="PLAYER", player_id=2, position="WR"),
+            TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=15),
+        ],
+        roster_sizes={1: 12, 2: 12},
+        max_roster_size=15,
+        min_roster_size=8,
+        available_draft_dollars={1: 50, 2: 50},
+        owned_pick_ids_by_team={1: {100, 101}, 2: {200}},
+        suppressed_positions={"K", "DEF"},
+        player_positions_by_id={},
+        trade_start_at=now - timedelta(days=5),
+        trade_end_at=now + timedelta(days=10),
+        allow_playoff_trades=True,
+        is_playoff=False,
+        max_future_year_offset=2,
+        current_season=2026,
+        now=now,
+    )
+
+    report = validate_trade_request(context)
+
+    assert report.valid
+    assert not report.errors
+
+
+# ==== ADDITIONAL EDGE CASES AND COMPREHENSIVE NEGATIVE TESTS ====
+
+
+def test_validate_trade_window_blocks_not_yet_open_window():
+    now = datetime.now(UTC)
+    report = validate_trade_window(
+        trade_start_at=now + timedelta(days=2),
+        trade_end_at=now + timedelta(days=10),
+        allow_playoff_trades=True,
+        is_playoff=False,
+        now=now,
+    )
+
+    assert not report.valid
+    assert any("not open yet" in message for message in report.errors.get("trade_window", []))
+
+
+def test_validate_trade_window_blocks_playoffs_when_disabled():
+    now = datetime.now(UTC)
+    report = validate_trade_window(
+        trade_start_at=now - timedelta(days=1),
+        trade_end_at=now + timedelta(days=10),
+        allow_playoff_trades=False,
+        is_playoff=True,
+        now=now,
+    )
+
+    assert not report.valid
+    assert any("disabled during playoffs" in message for message in report.errors.get("trade_window", []))
+
+
+def test_validate_draft_pick_ownership_detects_unowned_pick():
+    report = validate_draft_pick_ownership(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=999, season_year=2026)],
+        assets_from_b=[],
+        owned_pick_ids_by_team={1: {1, 2, 3}},
+        max_future_year_offset=2,
+        current_season=2026,
+    )
+
+    assert not report.valid
+    assert "assets_from_a[0]" in report.errors
+    assert any("does not own" in message for message in report.errors["assets_from_a[0]"])
+
+
+def test_validate_draft_pick_ownership_detects_future_year_beyond_limit():
+    report = validate_draft_pick_ownership(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[TradeAssetInput(asset_type="DRAFT_PICK", draft_pick_id=10, season_year=2030)],
+        assets_from_b=[],
+        owned_pick_ids_by_team={1: {10}},
+        max_future_year_offset=2,
+        current_season=2026,
+    )
+
+    assert not report.valid
+    assert "assets_from_a[0]" in report.errors
+    assert any("beyond allowed future year limit" in message for message in report.errors["assets_from_a[0]"])
+
+
+def test_validate_draft_capital_rejects_overages_on_both_sides():
+    report = validate_draft_capital(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=100)],
+        assets_from_b=[TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=75)],
+        available_draft_dollars={1: 50, 2: 60},
+    )
+
+    assert not report.valid
+    assert "assets_from_a" in report.errors
+    assert "assets_from_b" in report.errors
+
+
+def test_validate_roster_limits_rejects_below_minimum():
+    report = validate_roster_limits(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[
+            TradeAssetInput(asset_type="PLAYER", player_id=1),
+            TradeAssetInput(asset_type="PLAYER", player_id=2),
+            TradeAssetInput(asset_type="PLAYER", player_id=3),
+        ],
+        assets_from_b=[],
+        roster_sizes={1: 8, 2: 12},
+        max_roster_size=15,
+        min_roster_size=8,
+    )
+
+    assert not report.valid
+    assert "assets_from_a" in report.errors
+
+
+def test_validate_roster_limits_rejects_above_maximum():
+    report = validate_roster_limits(
+        team_a_id=1,
+        team_b_id=2,
+        assets_from_a=[],
+        assets_from_b=[
+            TradeAssetInput(asset_type="PLAYER", player_id=1),
+            TradeAssetInput(asset_type="PLAYER", player_id=2),
+            TradeAssetInput(asset_type="PLAYER", player_id=3),
+        ],
+        roster_sizes={1: 14, 2: 12},  # Team A at 14 receiving 3 would be 17 > max 15
+        max_roster_size=15,
+        min_roster_size=8,
+    )
+
+    assert not report.valid
+    assert "assets_from_a" in report.errors  # Team A roster is what goes out of bounds
+
+
+def test_validate_position_suppression_uses_provided_position_over_lookup():
+    """When position is provided in asset, it takes precedence over player_positions_by_id lookup."""
+    report = validate_position_suppression(
+        assets_from_a=[TradeAssetInput(asset_type="PLAYER", player_id=1, position="K")],
+        assets_from_b=[],
+        suppressed_positions={"K"},
+        player_positions_by_id={1: "RB"},  # This should be ignored in favor of provided position
+    )
+
+    assert not report.valid
+    assert "assets_from_a[0]" in report.errors
+
+
+def test_validate_position_suppression_falls_back_to_lookup_when_not_provided():
+    """When position is not provided, use player_positions_by_id."""
+    report = validate_position_suppression(
+        assets_from_a=[TradeAssetInput(asset_type="PLAYER", player_id=1)],
+        assets_from_b=[],
+        suppressed_positions={"K"},
+        player_positions_by_id={1: "K"},
+    )
+
+    assert not report.valid
+    assert "assets_from_a[0]" in report.errors
+
+
+def test_validate_multi_asset_trade_rejects_invalid_asset_type():
+    report = validate_multi_asset_trade(
+        assets_from_a=[TradeAssetInput(asset_type="INVALID_TYPE", player_id=1)],
+        assets_from_b=[TradeAssetInput(asset_type="PLAYER", player_id=2)],
+    )
+
+    assert not report.valid
+    assert "assets_from_a[0]" in report.errors
+    assert any("must be one of" in message for message in report.errors["assets_from_a[0]"])
+
+
+def test_validate_multi_asset_trade_rejects_player_without_id():
+    report = validate_multi_asset_trade(
+        assets_from_a=[TradeAssetInput(asset_type="PLAYER")],
+        assets_from_b=[TradeAssetInput(asset_type="PLAYER", player_id=1)],
+    )
+
+    assert not report.valid
+    assert "assets_from_a[0]" in report.errors
+
+
+def test_validate_multi_asset_trade_rejects_zero_or_negative_draft_dollars():
+    report = validate_multi_asset_trade(
+        assets_from_a=[TradeAssetInput(asset_type="DRAFT_DOLLARS", amount=0)],
+        assets_from_b=[TradeAssetInput(asset_type="PLAYER", player_id=1)],
+    )
+
+    assert not report.valid
+    assert "assets_from_a[0]" in report.errors
+    assert any("greater than zero" in message for message in report.errors["assets_from_a[0]"])

--- a/backend/tests/test_trade_validation_service.py
+++ b/backend/tests/test_trade_validation_service.py
@@ -250,7 +250,7 @@ def test_validate_draft_capital_accepts_within_available_balance():
     assert not report.errors
 
 
-def test_validate_draft_capital_accepts_zero_dollars_when_other_assets_present():
+def test_validate_draft_capital_accepts_non_dollar_assets_without_violation():
     report = validate_draft_capital(
         team_a_id=1,
         team_b_id=2,
@@ -310,7 +310,9 @@ def test_validate_roster_limits_accepts_valid_trade():
     assert not report.errors
 
 
-def test_validate_roster_limits_accepts_boundary_sizes():
+def test_validate_roster_limits_accepts_trade_landing_exactly_at_min_and_max():
+    # Team A: 10 roster − 3 sent + 1 received = 8 (at min_roster_size)
+    # Team B: 13 roster − 1 sent + 3 received = 15 (at max_roster_size)
     report = validate_roster_limits(
         team_a_id=1,
         team_b_id=2,
@@ -320,7 +322,7 @@ def test_validate_roster_limits_accepts_boundary_sizes():
             TradeAssetInput(asset_type="PLAYER", player_id=3),
         ],
         assets_from_b=[TradeAssetInput(asset_type="PLAYER", player_id=4)],
-        roster_sizes={1: 15, 2: 8},
+        roster_sizes={1: 10, 2: 13},
         max_roster_size=15,
         min_roster_size=8,
     )


### PR DESCRIPTION
Closes #346

## Summary
The `TradeValidationService` was already implemented in main with all validation functions and infrastructure. This PR completes the acceptance criteria by adding comprehensive test coverage for positive and negative paths with clear error messages.

## What was already in main

### Services
- `validate_multi_asset_trade()` — checks asset types and structure
- `validate_trade_window()` — checks trade timing and playoff rules
- `validate_draft_pick_ownership()` — verifies pick ownership and future year limits
- `validate_draft_capital()` — checks draft dollar budgets
- `validate_position_suppression()` — blocks suppressed positions
- `validate_roster_limits()` — ensures roster size bounds
- `validate_trade_request()` — orchestrator combining all validations

### Data Structures
- `TradeAssetInput` — single asset representation
- `TradeValidationReport` — structured error output with keyed error messages
- `TradeValidationContext` — full trade context for validation

## Added in this PR

### Test Coverage Summary
**33 tests** covering:

#### Negative/Edge Cases (original 8 tests)
- Empty asset sides
- Closed trade windows
- Missing picks and future year violations
- Draft capital overages
- Fractional draft dollars
- Suppressed positions
- Out-of-bounds roster sizes
- Aggregated error handling

#### Happy Paths (10 new tests)
- Valid player and pick trades
- Mixed asset type trades
- Open trade windows
- Playoff trades when enabled
- Multiple draft picks within limits
- Draft capital within budgets
- Non-suppressed positions
- Valid roster size changes
- Full multi-asset trades with all asset types
- Boundary conditions (min/max roster sizes)

#### Additional Edge Cases (15 new tests)
- Not-yet-open trade windows
- Playoff trades when disabled
- Unowned picks
- Future year violations
- Draft capital overages on both sides
- Roster limits below minimum and above maximum
- Position lookup fallback behavior
- Invalid asset types
- Missing player IDs for player assets
- Zero/negative draft dollars

## Error Message Clarity
All validation functions return structured errors with clear keys and messages:
- Asset path errors: `assets_from_a[0]`, `assets_from_b[1]`, etc.
- Validation key errors: `trade_window`, `assets_from_a`, etc.
- Message examples:
  - "team does not own this draft pick"
  - "draft pick season is beyond allowed future year limit"
  - "trades are disabled during playoffs"
  - "team A roster would be out of bounds after trade (size=17)"

## Acceptance Criteria
- [x] Validation service covers all required checks ✓ (already in main)
- [x] Unit tests for positive and negative paths ✓ (33 comprehensive tests)
- [x] Clear error messages returned to callers ✓ (keyed, structured errors)