### PR TITLE
test: Trade submission API comprehensive integration tests (#349)

### DIFF
--- a/backend/tests/test_trade_router.py
+++ b/backend/tests/test_trade_router.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine
@@ -11,7 +10,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import models
 from backend.routers.trades import propose_trade, approve_trade, reject_trade, submit_trade_v2
 from backend.routers.trades import TradeSubmissionCreate, TradeAssetCreate
-from backend.services.transaction_service import get_acquisition_method
 from fastapi import HTTPException
 
 
@@ -189,6 +187,14 @@ def test_trade_proposal_respects_commissioner_trade_deadline():
 # ==== INTEGRATION TESTS FOR SUBMIT_TRADE_V2 (#349) ====
 
 
+class _SubmitCU:
+    """Minimal mock CurrentUser for submit_trade_v2 tests."""
+    def __init__(self, user):
+        self.id = user.id
+        self.league_id = user.league_id
+
+
+
 def test_submit_trade_v2_creates_pending_trade_with_events():
     """Trade created with Pending status and SUBMITTED event recorded."""
     db = setup_db()
@@ -203,11 +209,6 @@ def test_submit_trade_v2_creates_pending_trade_with_events():
     make_pick(db, team_a, p1)
     make_pick(db, team_b, p2)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
         team_b_id=team_b.id,
@@ -216,7 +217,7 @@ def test_submit_trade_v2_creates_pending_trade_with_events():
         proposal_note="Fair deal",
     )
 
-    result = submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+    result = submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(team_a))
     assert result["status"] == "PENDING"
     assert "trade_id" in result
 
@@ -259,11 +260,6 @@ def test_submit_trade_v2_rejects_unauthorized_user():
     make_pick(db, team_a, p1)
     make_pick(db, team_b, p2)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
         team_b_id=team_b.id,
@@ -272,7 +268,7 @@ def test_submit_trade_v2_rejects_unauthorized_user():
     )
 
     with pytest.raises(HTTPException) as exc:
-        submit_trade_v2(league.id, payload, db=db, current_user=CU(outsider))
+        submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(outsider))
     assert exc.value.status_code == 403
 
 
@@ -290,11 +286,6 @@ def test_submit_trade_v2_requires_team_a_submission():
     make_pick(db, team_a, p1)
     make_pick(db, team_b, p2)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
         team_b_id=team_b.id,
@@ -304,7 +295,7 @@ def test_submit_trade_v2_requires_team_a_submission():
 
     # Team B trying to submit as team A should fail
     with pytest.raises(HTTPException) as exc:
-        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_b))
+        submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(team_b))
     assert exc.value.status_code == 403
     assert "team_a_id" in str(exc.value.detail).lower() or "team A" in str(exc.value.detail)
 
@@ -322,11 +313,6 @@ def test_submit_trade_v2_rejects_same_team_both_sides():
     make_pick(db, team, p1)
     make_pick(db, team, p2)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team.id,
         team_b_id=team.id,
@@ -335,7 +321,7 @@ def test_submit_trade_v2_rejects_same_team_both_sides():
     )
 
     with pytest.raises(HTTPException) as exc:
-        submit_trade_v2(league.id, payload, db=db, current_user=CU(team))
+        submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(team))
     assert exc.value.status_code == 400
     assert "different" in str(exc.value.detail).lower()
 
@@ -356,11 +342,6 @@ def test_submit_trade_v2_rejects_player_not_owned():
     make_pick(db, team_b, p_other)
     # p_not_owned is not owned by anyone
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
         team_b_id=team_b.id,
@@ -369,7 +350,7 @@ def test_submit_trade_v2_rejects_player_not_owned():
     )
 
     with pytest.raises(HTTPException) as exc:
-        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+        submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(team_a))
     assert exc.value.status_code == 400
     assert "does not own" in str(exc.value.detail).lower()
 
@@ -388,11 +369,6 @@ def test_submit_trade_v2_rejects_invalid_validation():
     make_pick(db, team_a, p1)
     make_pick(db, team_b, p2)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     # Try to trade 50 dollars from team_a with only 10 available
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
@@ -402,7 +378,7 @@ def test_submit_trade_v2_rejects_invalid_validation():
     )
 
     with pytest.raises(HTTPException) as exc:
-        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+        submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(team_a))
     assert exc.value.status_code == 400
     assert "draft dollar" in str(exc.value.detail).lower() or "cannot trade" in str(exc.value.detail).lower()
 
@@ -423,11 +399,6 @@ def test_submit_trade_v2_multi_asset_trade():
     pick_b = make_pick(db, team_b, p2)
     make_pick(db, team_a, p3)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
         team_b_id=team_b.id,
@@ -441,7 +412,7 @@ def test_submit_trade_v2_multi_asset_trade():
         ],
     )
 
-    result = submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+    result = submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(team_a))
     assert result["status"] == "PENDING"
 
     trade = db.get(models.Trade, result["trade_id"])
@@ -482,11 +453,6 @@ def test_submit_trade_v2_respects_commissioner_deadline():
     make_pick(db, team_a, p1)
     make_pick(db, team_b, p2)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
         team_b_id=team_b.id,
@@ -495,7 +461,7 @@ def test_submit_trade_v2_respects_commissioner_deadline():
     )
 
     with pytest.raises(HTTPException) as exc:
-        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+        submit_trade_v2(league.id, payload, db=db, current_user=_SubmitCU(team_a))
     assert exc.value.status_code == 400
     assert "closed" in str(exc.value.detail).lower() or "trade" in str(exc.value.detail).lower()
 
@@ -516,11 +482,6 @@ def test_submit_trade_v2_league_access_control():
     make_pick(db, team_a, p1)
     make_pick(db, team_a, p2)
 
-    class CU:
-        def __init__(self, user):
-            self.id = user.id
-            self.league_id = user.league_id
-
     payload = TradeSubmissionCreate(
         team_a_id=team_a.id,
         team_b_id=team_a.id + 1000,
@@ -529,5 +490,5 @@ def test_submit_trade_v2_league_access_control():
     )
 
     with pytest.raises(HTTPException) as exc:
-        submit_trade_v2(league2.id, payload, db=db, current_user=CU(team_a))
+        submit_trade_v2(league2.id, payload, db=db, current_user=_SubmitCU(team_a))
     assert exc.value.status_code == 403

--- a/backend/tests/test_trade_router.py
+++ b/backend/tests/test_trade_router.py
@@ -9,7 +9,8 @@ from sqlalchemy.orm import sessionmaker
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import models
-from backend.routers.trades import propose_trade, approve_trade, reject_trade
+from backend.routers.trades import propose_trade, approve_trade, reject_trade, submit_trade_v2
+from backend.routers.trades import TradeSubmissionCreate, TradeAssetCreate
 from backend.services.transaction_service import get_acquisition_method
 from fastapi import HTTPException
 
@@ -183,3 +184,350 @@ def test_trade_proposal_respects_commissioner_trade_deadline():
 
     assert exc.value.status_code == 400
     assert "Trade proposals are closed" in str(exc.value.detail)
+
+
+# ==== INTEGRATION TESTS FOR SUBMIT_TRADE_V2 (#349) ====
+
+
+def test_submit_trade_v2_creates_pending_trade_with_events():
+    """Trade created with Pending status and SUBMITTED event recorded."""
+    db = setup_db()
+    league = make_league(db)
+    db.add(models.LeagueSettings(league_id=league.id, roster_size=15))
+    db.commit()
+
+    team_a = make_user(db, league, "team_a", budget=50)
+    team_b = make_user(db, league, "team_b", budget=50)
+    p1 = make_player(db, "Player A")
+    p2 = make_player(db, "Player B")
+    make_pick(db, team_a, p1)
+    make_pick(db, team_b, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=p1.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p2.id)],
+        proposal_note="Fair deal",
+    )
+
+    result = submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+    assert result["status"] == "PENDING"
+    assert "trade_id" in result
+
+    # Verify trade exists with correct status
+    trade = db.get(models.Trade, result["trade_id"])
+    assert trade is not None
+    assert trade.status == "PENDING"
+    assert trade.league_id == league.id
+    assert trade.team_a_id == team_a.id
+    assert trade.team_b_id == team_b.id
+
+    # Verify assets were created
+    assert len(trade.assets) == 2
+    assets_by_side = {asset.asset_side: asset for asset in trade.assets}
+    assert assets_by_side["A"].asset_type == "PLAYER"
+    assert assets_by_side["A"].player_id == p1.id
+    assert assets_by_side["B"].asset_type == "PLAYER"
+    assert assets_by_side["B"].player_id == p2.id
+
+    # Verify SUBMITTED event was recorded
+    assert len(trade.events) >= 1
+    submitted_event = next((e for e in trade.events if e.event_type == "SUBMITTED"), None)
+    assert submitted_event is not None
+    assert submitted_event.actor_user_id == team_a.id
+    assert submitted_event.metadata_json.get("proposal_note") == "Fair deal"
+
+
+def test_submit_trade_v2_rejects_unauthorized_user():
+    """Unauthorized access rejected when user not in either team."""
+    db = setup_db()
+    league = make_league(db)
+    db.add(models.LeagueSettings(league_id=league.id))
+    db.commit()
+
+    team_a = make_user(db, league, "team_a", budget=50)
+    team_b = make_user(db, league, "team_b", budget=50)
+    outsider = make_user(db, league, "outsider", budget=50)
+    p1 = make_player(db, "P1")
+    p2 = make_player(db, "P2")
+    make_pick(db, team_a, p1)
+    make_pick(db, team_b, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=p1.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p2.id)],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        submit_trade_v2(league.id, payload, db=db, current_user=CU(outsider))
+    assert exc.value.status_code == 403
+
+
+def test_submit_trade_v2_requires_team_a_submission():
+    """Trade must be submitted by team_a user."""
+    db = setup_db()
+    league = make_league(db)
+    db.add(models.LeagueSettings(league_id=league.id))
+    db.commit()
+
+    team_a = make_user(db, league, "team_a", budget=50)
+    team_b = make_user(db, league, "team_b", budget=50)
+    p1 = make_player(db, "P1")
+    p2 = make_player(db, "P2")
+    make_pick(db, team_a, p1)
+    make_pick(db, team_b, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=p1.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p2.id)],
+    )
+
+    # Team B trying to submit as team A should fail
+    with pytest.raises(HTTPException) as exc:
+        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_b))
+    assert exc.value.status_code == 403
+    assert "team_a_id" in str(exc.value.detail).lower() or "team A" in str(exc.value.detail)
+
+
+def test_submit_trade_v2_rejects_same_team_both_sides():
+    """Rejects when same team on both sides."""
+    db = setup_db()
+    league = make_league(db)
+    db.add(models.LeagueSettings(league_id=league.id))
+    db.commit()
+
+    team = make_user(db, league, "team", budget=50)
+    p1 = make_player(db, "P1")
+    p2 = make_player(db, "P2")
+    make_pick(db, team, p1)
+    make_pick(db, team, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team.id,
+        team_b_id=team.id,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=p1.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p2.id)],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        submit_trade_v2(league.id, payload, db=db, current_user=CU(team))
+    assert exc.value.status_code == 400
+    assert "different" in str(exc.value.detail).lower()
+
+
+def test_submit_trade_v2_rejects_player_not_owned():
+    """Rejects when team doesn't own offered player."""
+    db = setup_db()
+    league = make_league(db)
+    db.add(models.LeagueSettings(league_id=league.id))
+    db.commit()
+
+    team_a = make_user(db, league, "team_a", budget=50)
+    team_b = make_user(db, league, "team_b", budget=50)
+    p_owned = make_player(db, "Owned")
+    p_not_owned = make_player(db, "NotOwned")
+    p_other = make_player(db, "Other")
+    make_pick(db, team_a, p_owned)
+    make_pick(db, team_b, p_other)
+    # p_not_owned is not owned by anyone
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=p_not_owned.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p_other.id)],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+    assert exc.value.status_code == 400
+    assert "does not own" in str(exc.value.detail).lower()
+
+
+def test_submit_trade_v2_rejects_invalid_validation():
+    """Rejects trade that fails validation (e.g., insufficient budget)."""
+    db = setup_db()
+    league = make_league(db)
+    db.add(models.LeagueSettings(league_id=league.id))
+    db.commit()
+
+    team_a = make_user(db, league, "team_a", budget=10)  # Low budget
+    team_b = make_user(db, league, "team_b", budget=50)
+    p1 = make_player(db, "P1")
+    p2 = make_player(db, "P2")
+    make_pick(db, team_a, p1)
+    make_pick(db, team_b, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    # Try to trade 50 dollars from team_a with only 10 available
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[TradeAssetCreate(asset_type="DRAFT_DOLLARS", amount=50)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p2.id)],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+    assert exc.value.status_code == 400
+    assert "draft dollar" in str(exc.value.detail).lower() or "cannot trade" in str(exc.value.detail).lower()
+
+
+def test_submit_trade_v2_multi_asset_trade():
+    """Successfully submit multi-asset trade (players + picks + dollars)."""
+    db = setup_db()
+    league = make_league(db)
+    db.add(models.LeagueSettings(league_id=league.id, roster_size=15))
+    db.commit()
+
+    team_a = make_user(db, league, "team_a", budget=100)
+    team_b = make_user(db, league, "team_b", budget=100)
+    p1 = make_player(db, "P1")
+    p2 = make_player(db, "P2")
+    p3 = make_player(db, "P3")
+    pick_a = make_pick(db, team_a, p1)
+    pick_b = make_pick(db, team_b, p2)
+    make_pick(db, team_a, p3)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[
+            TradeAssetCreate(asset_type="PLAYER", player_id=p1.id),
+            TradeAssetCreate(asset_type="DRAFT_DOLLARS", amount=25),
+        ],
+        assets_from_b=[
+            TradeAssetCreate(asset_type="PLAYER", player_id=p2.id),
+            TradeAssetCreate(asset_type="DRAFT_PICK", draft_pick_id=pick_b.id, season_year=2027),
+        ],
+    )
+
+    result = submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+    assert result["status"] == "PENDING"
+
+    trade = db.get(models.Trade, result["trade_id"])
+    assert len(trade.assets) == 4
+    # 2 from team_a, 2 from team_b
+    a_assets = [a for a in trade.assets if a.asset_side == "A"]
+    b_assets = [a for a in trade.assets if a.asset_side == "B"]
+    assert len(a_assets) == 2
+    assert len(b_assets) == 2
+
+    # Verify asset types
+    a_types = {a.asset_type for a in a_assets}
+    assert "PLAYER" in a_types
+    assert "DRAFT_DOLLARS" in a_types
+    b_types = {a.asset_type for a in b_assets}
+    assert "PLAYER" in b_types
+    assert "DRAFT_PICK" in b_types
+
+
+def test_submit_trade_v2_respects_commissioner_deadline():
+    """Rejects trade when past commissioner-set deadline."""
+    db = setup_db()
+    league = make_league(db)
+    # Set trade deadline to past
+    db.add(
+        models.LeagueSettings(
+            league_id=league.id,
+            trade_deadline="2000-01-01T00:00:00Z",
+            roster_size=15,
+        )
+    )
+    db.commit()
+
+    team_a = make_user(db, league, "team_a", budget=50)
+    team_b = make_user(db, league, "team_b", budget=50)
+    p1 = make_player(db, "P1")
+    p2 = make_player(db, "P2")
+    make_pick(db, team_a, p1)
+    make_pick(db, team_b, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=p1.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p2.id)],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        submit_trade_v2(league.id, payload, db=db, current_user=CU(team_a))
+    assert exc.value.status_code == 400
+    assert "closed" in str(exc.value.detail).lower() or "trade" in str(exc.value.detail).lower()
+
+
+def test_submit_trade_v2_league_access_control():
+    """Rejects when user's league doesn't match requested league."""
+    db = setup_db()
+    league1 = make_league(db, "L1")
+    league2 = make_league(db, "L2")
+    db.add(models.LeagueSettings(league_id=league1.id))
+    db.add(models.LeagueSettings(league_id=league2.id))
+    db.commit()
+
+    team_a = make_user(db, league1, "team_a", budget=50)
+    # User belongs to league1 but tries to submit trade in league2
+    p1 = make_player(db, "P1")
+    p2 = make_player(db, "P2")
+    make_pick(db, team_a, p1)
+    make_pick(db, team_a, p2)
+
+    class CU:
+        def __init__(self, user):
+            self.id = user.id
+            self.league_id = user.league_id
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_a.id + 1000,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=p1.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=p2.id)],
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        submit_trade_v2(league2.id, payload, db=db, current_user=CU(team_a))
+    assert exc.value.status_code == 403


### PR DESCRIPTION
Closes #349

## Summary
The `submit_trade_v2` endpoint was already fully implemented in `backend/routers/trades.py`. This PR completes the acceptance criteria for #349 by adding comprehensive integration tests that verify the complete submission workflow.

## What was already in main

### Endpoint Implementation
- `POST /leagues/{league_id}/submit-v2` — Trade submission endpoint
- Full validation using `validate_trade_request()` service
- Trade window enforcement via `enforce_commissioner_deadline()`
- Player ownership validation at submission time
- Multi-asset support (players, picks, draft capital)
- Event recording (SUBMITTED events)
- Notification dispatch

### Key Features
- Authorization checks (league access, team membership)
- Team A submission enforcement
- Comprehensive validation pipeline
- Atomic transaction (all-or-nothing)
- Trade record creation with PENDING status

## Added in this PR

### Integration Tests (9 new tests)
All tests verify the complete submission flow end-to-end:

1. `test_submit_trade_v2_creates_pending_trade_with_events`
   - Happy path: Creates trade with PENDING status
   - Verifies assets are saved correctly
   - Confirms SUBMITTED event is recorded

2. `test_submit_trade_v2_rejects_unauthorized_user`
   - Verifies 403 Forbidden when user not in either team

3. `test_submit_trade_v2_requires_team_a_submission`
   - Confirms only team_a can submit the trade
   - Team B attempt is rejected

4. `test_submit_trade_v2_rejects_same_team_both_sides`
   - Validates team_a ≠ team_b

5. `test_submit_trade_v2_rejects_player_not_owned`
   - Ownership validation at submission time
   - Prevents unexecutable trades from entering queue

6. `test_submit_trade_v2_rejects_invalid_validation`
   - Comprehensive validation enforcement
   - Tests draft capital insufficient error

7. `test_submit_trade_v2_multi_asset_trade`
   - Multi-asset support (players, picks, dollars)
   - Verifies all assets persisted correctly

8. `test_submit_trade_v2_respects_commissioner_deadline`
   - Trade window enforcement
   - Rejects trades past deadline

9. `test_submit_trade_v2_league_access_control`
   - Cross-league access prevention
   - Verifies league isolation

## Acceptance Criteria
- [x] Trades created with Pending status ✓ (test #1)
- [x] Unauthorized or invalid trades rejected ✓ (tests #2-8)
- [x] Integration tests cover submission paths ✓ (all 9 tests)

## Test Results
```
12 passed (3 existing + 9 new), 0 failed
```