### PR TITLE
test: commissioner review queue API integration tests (#351)

### DIFF
--- a/backend/tests/test_trade_review_v2.py
+++ b/backend/tests/test_trade_review_v2.py
@@ -12,6 +12,7 @@ import backend.services.notifications as notifications_module
 from backend.routers.trades import (
     TradeReviewAction,
     approve_trade_v2,
+    get_trade_detail_v2,
     get_trade_history_v2,
     get_pending_trades_v2,
     reject_trade_v2,
@@ -337,3 +338,168 @@ def test_approve_trade_v2_rolls_back_on_invalid_player_ownership():
     # budget unchanged due to rollback
     refreshed_owner = db.get(models.User, owner_row.id)
     assert refreshed_owner.future_draft_budget == owner_row.future_draft_budget
+
+
+# ─── Additional edge case tests for #351 acceptance criteria ─────────────────
+
+
+def test_get_trade_detail_v2_returns_full_trade():
+    """get_trade_detail_v2 returns serialised trade with assets from both sides."""
+    db = setup_db()
+    league, commissioner, trade_id = create_pending_trade(db)
+
+    result = get_trade_detail_v2(league.id, trade_id, db=db, current_user=CU(commissioner))
+
+    assert result["id"] == trade_id
+    assert result["status"] == "PENDING"
+    assert result["league_id"] == league.id
+    assert len(result["assets_from_a"]) == 1
+    assert len(result["assets_from_b"]) == 1
+    assert result["assets_from_a"][0]["asset_type"] == "PLAYER"
+    assert result["assets_from_b"][0]["asset_type"] == "PLAYER"
+
+
+def test_get_trade_detail_v2_returns_404_for_unknown_trade():
+    """get_trade_detail_v2 returns 404 for a trade ID that doesn't exist."""
+    db = setup_db()
+    league, commissioner, _ = create_pending_trade(db)
+
+    with pytest.raises(HTTPException) as exc:
+        get_trade_detail_v2(league.id, 9999, db=db, current_user=CU(commissioner))
+    assert exc.value.status_code == 404
+
+
+def test_get_trade_history_v2_returns_submitted_event():
+    """get_trade_history_v2 returns at least the SUBMITTED event for a pending trade."""
+    db = setup_db()
+    league, commissioner, trade_id = create_pending_trade(db)
+
+    events = get_trade_history_v2(league.id, trade_id, db=db, current_user=CU(commissioner))
+
+    assert len(events) >= 1
+    event_types = [e["event_type"] for e in events]
+    assert "SUBMITTED" in event_types
+
+
+def test_get_trade_history_v2_records_approved_event():
+    """get_trade_history_v2 includes APPROVED event after approval."""
+    import backend.services.notifications as notifications_module
+    db = setup_db()
+    league, commissioner, trade_id = create_pending_trade(db)
+
+    # Patch notifications to avoid side effects
+    original = getattr(notifications_module, "send_notification", None)
+    notifications_module.send_notification = lambda *a, **kw: None
+
+    approve_trade_v2(
+        league.id,
+        trade_id,
+        TradeReviewAction(commissioner_comments="LGTM"),
+        db=db,
+        current_user=CU(commissioner),
+    )
+
+    if original is not None:
+        notifications_module.send_notification = original
+
+    events = get_trade_history_v2(league.id, trade_id, db=db, current_user=CU(commissioner))
+    event_types = [e["event_type"] for e in events]
+    assert "APPROVED" in event_types
+
+
+def test_approve_trade_v2_rejects_already_approved_trade():
+    """Attempting to approve an already-approved trade returns 400."""
+    import backend.services.notifications as notifications_module
+    db = setup_db()
+    league, commissioner, trade_id = create_pending_trade(db)
+
+    notifications_module.send_notification = lambda *a, **kw: None
+
+    approve_trade_v2(
+        league.id, trade_id, TradeReviewAction(), db=db, current_user=CU(commissioner)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        approve_trade_v2(
+            league.id, trade_id, TradeReviewAction(), db=db, current_user=CU(commissioner)
+        )
+    assert exc.value.status_code == 400
+    assert "pending" in str(exc.value.detail).lower()
+
+
+def test_reject_trade_v2_rejects_already_rejected_trade():
+    """Attempting to reject an already-rejected trade returns 400."""
+    import backend.services.notifications as notifications_module
+    db = setup_db()
+    league, commissioner, trade_id = create_pending_trade(db)
+
+    notifications_module.send_notification = lambda *a, **kw: None
+
+    reject_trade_v2(
+        league.id,
+        trade_id,
+        TradeReviewAction(commissioner_comments="No thanks"),
+        db=db,
+        current_user=CU(commissioner),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        reject_trade_v2(
+            league.id,
+            trade_id,
+            TradeReviewAction(commissioner_comments="Again"),
+            db=db,
+            current_user=CU(commissioner),
+        )
+    assert exc.value.status_code == 400
+
+
+def test_reject_trade_v2_persists_rejection_reason():
+    """Rejection reason (commissioner_comments) is saved to the trade record."""
+    import backend.services.notifications as notifications_module
+    db = setup_db()
+    league, commissioner, trade_id = create_pending_trade(db)
+
+    notifications_module.send_notification = lambda *a, **kw: None
+
+    result = reject_trade_v2(
+        league.id,
+        trade_id,
+        TradeReviewAction(commissioner_comments="Unbalanced trade"),
+        db=db,
+        current_user=CU(commissioner),
+    )
+
+    assert result["trade"]["status"] == "REJECTED"
+    assert result["trade"]["commissioner_comments"] == "Unbalanced trade"
+
+    trade = db.get(models.Trade, trade_id)
+    assert trade.commissioner_comments == "Unbalanced trade"
+    assert trade.rejected_at is not None
+
+    # REJECTED event should also be in history
+    events = get_trade_history_v2(league.id, trade_id, db=db, current_user=CU(commissioner))
+    event_types = [e["event_type"] for e in events]
+    assert "REJECTED" in event_types
+
+
+def test_pending_trade_list_v2_excludes_approved_and_rejected():
+    """get_pending_trades_v2 only returns PENDING trades, not resolved ones."""
+    import backend.services.notifications as notifications_module
+    db = setup_db()
+    league, commissioner, trade_id = create_pending_trade(db)
+
+    notifications_module.send_notification = lambda *a, **kw: None
+
+    reject_trade_v2(
+        league.id,
+        trade_id,
+        TradeReviewAction(commissioner_comments="reject"),
+        db=db,
+        current_user=CU(commissioner),
+    )
+
+    pending = get_pending_trades_v2(league.id, db=db, current_user=CU(commissioner))
+    pending_ids = [t["id"] for t in pending]
+    assert trade_id not in pending_ids
+

--- a/backend/tests/test_trade_review_v2.py
+++ b/backend/tests/test_trade_review_v2.py
@@ -381,15 +381,17 @@ def test_get_trade_history_v2_returns_submitted_event():
     assert "SUBMITTED" in event_types
 
 
-def test_get_trade_history_v2_records_approved_event():
+def test_get_trade_history_v2_records_approved_event(monkeypatch):
     """get_trade_history_v2 includes APPROVED event after approval."""
     import backend.services.notifications as notifications_module
     db = setup_db()
     league, commissioner, trade_id = create_pending_trade(db)
 
-    # Patch notifications to avoid side effects
-    original = getattr(notifications_module, "send_notification", None)
-    notifications_module.send_notification = lambda *a, **kw: None
+    monkeypatch.setattr(
+        notifications_module.NotifyService,
+        "send_transactional_email",
+        lambda *a, **kw: None,
+    )
 
     approve_trade_v2(
         league.id,
@@ -399,21 +401,22 @@ def test_get_trade_history_v2_records_approved_event():
         current_user=CU(commissioner),
     )
 
-    if original is not None:
-        notifications_module.send_notification = original
-
     events = get_trade_history_v2(league.id, trade_id, db=db, current_user=CU(commissioner))
     event_types = [e["event_type"] for e in events]
     assert "APPROVED" in event_types
 
 
-def test_approve_trade_v2_rejects_already_approved_trade():
+def test_approve_trade_v2_rejects_already_approved_trade(monkeypatch):
     """Attempting to approve an already-approved trade returns 400."""
     import backend.services.notifications as notifications_module
     db = setup_db()
     league, commissioner, trade_id = create_pending_trade(db)
 
-    notifications_module.send_notification = lambda *a, **kw: None
+    monkeypatch.setattr(
+        notifications_module.NotifyService,
+        "send_transactional_email",
+        lambda *a, **kw: None,
+    )
 
     approve_trade_v2(
         league.id, trade_id, TradeReviewAction(), db=db, current_user=CU(commissioner)
@@ -427,13 +430,17 @@ def test_approve_trade_v2_rejects_already_approved_trade():
     assert "pending" in str(exc.value.detail).lower()
 
 
-def test_reject_trade_v2_rejects_already_rejected_trade():
+def test_reject_trade_v2_rejects_already_rejected_trade(monkeypatch):
     """Attempting to reject an already-rejected trade returns 400."""
     import backend.services.notifications as notifications_module
     db = setup_db()
     league, commissioner, trade_id = create_pending_trade(db)
 
-    notifications_module.send_notification = lambda *a, **kw: None
+    monkeypatch.setattr(
+        notifications_module.NotifyService,
+        "send_transactional_email",
+        lambda *a, **kw: None,
+    )
 
     reject_trade_v2(
         league.id,
@@ -454,13 +461,17 @@ def test_reject_trade_v2_rejects_already_rejected_trade():
     assert exc.value.status_code == 400
 
 
-def test_reject_trade_v2_persists_rejection_reason():
+def test_reject_trade_v2_persists_rejection_reason(monkeypatch):
     """Rejection reason (commissioner_comments) is saved to the trade record."""
     import backend.services.notifications as notifications_module
     db = setup_db()
     league, commissioner, trade_id = create_pending_trade(db)
 
-    notifications_module.send_notification = lambda *a, **kw: None
+    monkeypatch.setattr(
+        notifications_module.NotifyService,
+        "send_transactional_email",
+        lambda *a, **kw: None,
+    )
 
     result = reject_trade_v2(
         league.id,
@@ -483,23 +494,53 @@ def test_reject_trade_v2_persists_rejection_reason():
     assert "REJECTED" in event_types
 
 
-def test_pending_trade_list_v2_excludes_approved_and_rejected():
+def test_pending_trade_list_v2_excludes_approved_and_rejected(monkeypatch):
     """get_pending_trades_v2 only returns PENDING trades, not resolved ones."""
     import backend.services.notifications as notifications_module
     db = setup_db()
-    league, commissioner, trade_id = create_pending_trade(db)
+    league, commissioner, trade_id_reject = create_pending_trade(db)
 
-    notifications_module.send_notification = lambda *a, **kw: None
+    team_a = db.query(models.User).filter_by(league_id=league.id, username="team-a").first()
+    team_b = db.query(models.User).filter_by(league_id=league.id, username="team-b").first()
+    player_c = make_player(db, "Player C", position="RB")
+    player_d = make_player(db, "Player D", position="WR")
+    make_pick(db, league.id, team_a.id, player_c.id)
+    make_pick(db, league.id, team_b.id, player_d.id)
+
+    payload = TradeSubmissionCreate(
+        team_a_id=team_a.id,
+        team_b_id=team_b.id,
+        assets_from_a=[TradeAssetCreate(asset_type="PLAYER", player_id=player_c.id)],
+        assets_from_b=[TradeAssetCreate(asset_type="PLAYER", player_id=player_d.id)],
+    )
+    created = submit_trade_v2(league.id, payload, db=db, current_user=SubmitCU(team_a))
+    trade_id_approve = created["trade_id"]
+
+    monkeypatch.setattr(
+        notifications_module.NotifyService,
+        "send_transactional_email",
+        lambda *a, **kw: None,
+    )
 
     reject_trade_v2(
         league.id,
-        trade_id,
+        trade_id_reject,
         TradeReviewAction(commissioner_comments="reject"),
+        db=db,
+        current_user=CU(commissioner),
+    )
+
+    approve_trade_v2(
+        league.id,
+        trade_id_approve,
+        TradeReviewAction(commissioner_comments="approve"),
         db=db,
         current_user=CU(commissioner),
     )
 
     pending = get_pending_trades_v2(league.id, db=db, current_user=CU(commissioner))
     pending_ids = [t["id"] for t in pending]
-    assert trade_id not in pending_ids
+    assert trade_id_reject not in pending_ids
+    assert trade_id_approve not in pending_ids
+    assert pending_ids == []
 


### PR DESCRIPTION
Closes #351

## Summary
The commissioner review queue API was already fully implemented in `backend/routers/trades.py`. This PR adds 8 additional integration tests on top of the 7 already in main, completing coverage for all acceptance criteria.

## Endpoints (already in main)
- `GET /trades/leagues/{league_id}/pending-v2` — List pending trades (commissioner-only)
- `GET /trades/leagues/{league_id}/{trade_id}-v2` — Trade detail with full asset breakdown
- `GET /trades/leagues/{league_id}/{trade_id}/history-v2` — Audit event timeline
- `POST /trades/leagues/{league_id}/{trade_id}/approve-v2` — Approve with optional comments
- `POST /trades/leagues/{league_id}/{trade_id}/reject-v2` — Reject with reason

## Added in this PR (8 new tests)

1. `test_get_trade_detail_v2_returns_full_trade` — Detail includes assets from both sides
2. `test_get_trade_detail_v2_returns_404_for_unknown_trade` — 404 for missing trade
3. `test_get_trade_history_v2_returns_submitted_event` — SUBMITTED event present on fresh trade
4. `test_get_trade_history_v2_records_approved_event` — APPROVED event in history after approval
5. `test_approve_trade_v2_rejects_already_approved_trade` — 400 on double-approve
6. `test_reject_trade_v2_rejects_already_rejected_trade` — 400 on double-reject
7. `test_reject_trade_v2_persists_rejection_reason` — Rejection reason persisted to DB and in history
8. `test_pending_trade_list_v2_excludes_approved_and_rejected` — List excludes resolved trades

## Acceptance Criteria
- [x] Commissioner can approve/reject pending trades ✓ (tests #5, #6 + existing)
- [x] Rejection reason persisted ✓ (test #7 explicitly validates DB + history)
- [x] Audit events emitted ✓ (tests #3, #4, #7 verify event timeline)

## Test Results
```
15 passed (7 existing + 8 new), 0 failed
```