### PR TITLE
feat: trade timeline config, trade builder, and commissioner review UI (#348, #350, #352)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,6 +46,7 @@ const ManageWaiverRules = lazy(
   () => import('./pages/commissioner/ManageWaiverRules')
 );
 const ManageTrades = lazy(() => import('./pages/commissioner/ManageTrades'));
+const TradeBuilder = lazy(() => import('./pages/TradeBuilder'));
 const ManageScoringRules = lazy(
   () => import('./pages/commissioner/ManageScoringRules')
 );
@@ -96,6 +97,7 @@ function resolveLayoutPageTitle(pathname) {
   if (pathname === '/commissioner/manage-owners') return 'Manage Owners';
   if (pathname === '/commissioner/manage-waiver-rules') return 'Manage Waiver Rules';
   if (pathname === '/commissioner/manage-trades') return 'Manage Trades';
+  if (pathname === '/trades/submit') return 'Trade Builder';
   if (pathname === '/commissioner/manage-scoring-rules') return 'Manage Scoring Rules';
   if (pathname === '/commissioner/manage-divisions') return 'Manage Divisions';
   if (pathname === '/commissioner/history-owner-mapping') return 'Historical Owner Mapping';
@@ -297,6 +299,7 @@ function AuthenticatedShell({
           />
           <Route path="/bug-report" element={<BugReport />} />
           <Route path="/keepers" element={<Keepers />} />
+          <Route path="/trades/submit" element={<TradeBuilder />} />
           <Route path="/analytics" element={<AnalyticsDashboard />} />
           <Route path="/playoffs" element={<PlayoffBracket />} />
           <Route

--- a/frontend/src/api/tradesApi.js
+++ b/frontend/src/api/tradesApi.js
@@ -1,15 +1,46 @@
 import apiClient from '@api/client';
 
+function isNotFound(error) {
+  return Number(error?.response?.status || 0) === 404;
+}
+
+function fromLegacyLeagueSettings(data = {}) {
+  const tradeEndAt = data.trade_deadline || null;
+  const isActive = tradeEndAt ? new Date(tradeEndAt).getTime() > Date.now() : true;
+  return {
+    trade_start_at: null,
+    trade_end_at: tradeEndAt,
+    timezone: 'UTC',
+    is_active: isActive,
+  };
+}
+
 // ── Trade Window Settings ───────────────────────────────────────────────────
 
 export async function fetchTradeWindowSettings(leagueId) {
-  const res = await apiClient.get(`/trades/leagues/${leagueId}/settings/trade-window`);
-  return res.data;
+  try {
+    const res = await apiClient.get(`/trades/leagues/${leagueId}/settings/trade-window`);
+    return res.data;
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    const legacy = await apiClient.get(`/leagues/${leagueId}/settings`);
+    return fromLegacyLeagueSettings(legacy.data);
+  }
 }
 
 export async function saveTradeWindowSettings(leagueId, payload) {
-  const res = await apiClient.put(`/trades/leagues/${leagueId}/settings/trade-window`, payload);
-  return res.data;
+  try {
+    const res = await apiClient.put(`/trades/leagues/${leagueId}/settings/trade-window`, payload);
+    return res.data;
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    // Legacy fallback: only trade_deadline exists on older league settings schema.
+    const legacyPayload = {
+      trade_deadline: payload.is_active ? payload.trade_end_at : new Date().toISOString(),
+    };
+    const res = await apiClient.put(`/leagues/${leagueId}/settings`, legacyPayload);
+    return fromLegacyLeagueSettings(res.data);
+  }
 }
 
 // ── Pending queue (commissioner) ────────────────────────────────────────────

--- a/frontend/src/api/tradesApi.js
+++ b/frontend/src/api/tradesApi.js
@@ -1,0 +1,70 @@
+import apiClient from '@api/client';
+
+// ── Trade Window Settings ───────────────────────────────────────────────────
+
+export async function fetchTradeWindowSettings(leagueId) {
+  const res = await apiClient.get(`/trades/leagues/${leagueId}/settings/trade-window`);
+  return res.data;
+}
+
+export async function saveTradeWindowSettings(leagueId, payload) {
+  const res = await apiClient.put(`/trades/leagues/${leagueId}/settings/trade-window`, payload);
+  return res.data;
+}
+
+// ── Pending queue (commissioner) ────────────────────────────────────────────
+
+export async function fetchPendingTrades(leagueId) {
+  const res = await apiClient.get(`/trades/leagues/${leagueId}/pending-v2`);
+  const data = res.data;
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.trades)) return data.trades;
+  if (Array.isArray(data?.items)) return data.items;
+  return [];
+}
+
+export async function fetchTradeDetail(leagueId, tradeId) {
+  const res = await apiClient.get(`/trades/leagues/${leagueId}/${tradeId}-v2`);
+  return res.data;
+}
+
+export async function fetchTradeHistory(leagueId, tradeId) {
+  const res = await apiClient.get(`/trades/leagues/${leagueId}/${tradeId}/history-v2`);
+  const data = res.data;
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.events)) return data.events;
+  return [];
+}
+
+export async function approveTrade(leagueId, tradeId, comments = '') {
+  const res = await apiClient.post(`/trades/leagues/${leagueId}/${tradeId}/approve-v2`, {
+    commissioner_comments: comments,
+  });
+  return res.data;
+}
+
+export async function rejectTrade(leagueId, tradeId, comments = '') {
+  const res = await apiClient.post(`/trades/leagues/${leagueId}/${tradeId}/reject-v2`, {
+    commissioner_comments: comments,
+  });
+  return res.data;
+}
+
+// ── Trade submission ────────────────────────────────────────────────────────
+
+export async function submitTrade(leagueId, payload) {
+  const res = await apiClient.post(`/trades/leagues/${leagueId}/submit-v2`, payload);
+  return res.data;
+}
+
+// ── Roster helpers ──────────────────────────────────────────────────────────
+
+export async function fetchTeamRoster(leagueId, teamId) {
+  const res = await apiClient.get(`/team/${teamId}`, { params: { league_id: leagueId } });
+  return Array.isArray(res.data) ? res.data : (res.data?.players ?? []);
+}
+
+export async function fetchLeagueTeams(leagueId) {
+  const res = await apiClient.get('/leagues/owners', { params: { league_id: leagueId } });
+  return Array.isArray(res.data) ? res.data : [];
+}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -19,6 +19,7 @@ import {
   FiAlertTriangle,
   FiClock,
   FiRefreshCw,
+  FiArrowLeftRight,
 } from 'react-icons/fi';
 
 // 1.1 COMPONENT DECLARED OUTSIDE (Fixes "Cannot create components during render")
@@ -160,6 +161,14 @@ export default function Sidebar({ isOpen, onClose, username, leagueId, onLogout,
             title="Keepers"
             desc="Manage off‑season keepers"
             icon={FiRepeat}
+            onClick={onClose}
+          />
+
+          <MenuBlock
+            to="/trades/submit"
+            title="Trades"
+            desc="Propose a trade"
+            icon={FiArrowLeftRight}
             onClick={onClose}
           />
 

--- a/frontend/src/pages/TradeBuilder.jsx
+++ b/frontend/src/pages/TradeBuilder.jsx
@@ -152,8 +152,13 @@ export default function TradeBuilder() {
   const [rosterB, setRosterB] = useState([]);
   const [rosterBLoading, setRosterBLoading] = useState(false);
 
-  // My roster (team A) loaded from /auth/me → team context
-  const myTeamId = localStorage.getItem('team_id') || localStorage.getItem('owner_id') || null;
+  // Auth flow persists user_id; keep owner/team fallbacks for compatibility.
+  const myTeamId =
+    (typeof window !== 'undefined' &&
+      (localStorage.getItem('user_id') ||
+        localStorage.getItem('owner_id') ||
+        localStorage.getItem('team_id'))) ||
+    null;
   const [rosterA, setRosterA] = useState([]);
 
   const [assetsFromA, setAssetsFromA] = useState([]);
@@ -211,8 +216,11 @@ export default function TradeBuilder() {
 
   const validate = () => {
     if (!leagueId) return 'No active league selected.';
+    if (!myTeamId) return 'Unable to determine your team context. Please refresh and try again.';
     if (!teamBId) return 'Please select a trade partner.';
-    if (assetsFromA.length === 0 && assetsFromB.length === 0) return 'Add at least one asset to the trade.';
+    if (assetsFromA.length === 0 || assetsFromB.length === 0) {
+      return 'Add at least one asset on both sides of the trade.';
+    }
     for (const a of assetsFromA) {
       if (a.asset_type === 'PLAYER' && !a.player_id) return 'Select a player for all your player assets.';
       if (a.asset_type === 'DRAFT_PICK' && !a.draft_pick_id) return 'Enter a pick ID for all draft pick assets.';
@@ -243,6 +251,7 @@ export default function TradeBuilder() {
         return base;
       };
       await submitTrade(leagueId, {
+        team_a_id: Number(myTeamId),
         team_b_id: Number(teamBId),
         assets_from_a: assetsFromA.map(buildAsset),
         assets_from_b: assetsFromB.map(buildAsset),

--- a/frontend/src/pages/TradeBuilder.jsx
+++ b/frontend/src/pages/TradeBuilder.jsx
@@ -1,0 +1,394 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { FiChevronLeft, FiPlus, FiTrash2 } from 'react-icons/fi';
+import { useActiveLeague } from '@context/LeagueContext';
+import PageTemplate from '@components/layout/PageTemplate';
+import { LoadingState, EmptyState } from '@components/common/AsyncState';
+import {
+  buttonPrimary,
+  buttonSecondary,
+  cardSurface,
+  inputBase,
+  textMuted,
+} from '@utils/uiStandards';
+import { fetchLeagueTeams, fetchTeamRoster, submitTrade } from '@api/tradesApi';
+
+/* ignore-breakpoints */
+
+const ASSET_TYPES = ['PLAYER', 'DRAFT_PICK', 'DRAFT_DOLLARS'];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function assetLabel(a) {
+  if (a.asset_type === 'PLAYER') return a.player_name || `Player #${a.player_id}`;
+  if (a.asset_type === 'DRAFT_PICK') return `Pick #${a.draft_pick_id}${a.season_year ? ` (${a.season_year})` : ''}`;
+  if (a.asset_type === 'DRAFT_DOLLARS') return `$${Number(a.amount || 0)} draft dollars`;
+  return a.asset_type;
+}
+
+// ── Asset Picker ─────────────────────────────────────────────────────────────
+
+function AssetRow({ asset, roster, onRemove, onChange }) {
+  const players = roster.filter((p) => p.player_id || p.id);
+
+  return (
+    <div className="flex items-start gap-2 p-2 bg-slate-100 dark:bg-slate-800 rounded-lg">
+      {/* Asset type selector */}
+      <select
+        className="rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-cyan-500/40 min-w-[130px]"
+        value={asset.asset_type}
+        onChange={(e) => onChange({ ...asset, asset_type: e.target.value, player_id: null, draft_pick_id: null, amount: '' })}
+      >
+        {ASSET_TYPES.map((t) => <option key={t} value={t}>{t.replace('_', ' ')}</option>)}
+      </select>
+
+      {/* Dynamic fields per type */}
+      {asset.asset_type === 'PLAYER' && (
+        <select
+          className="flex-1 rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+          value={asset.player_id || ''}
+          onChange={(e) => onChange({ ...asset, player_id: e.target.value ? Number(e.target.value) : null })}
+        >
+          <option value="">— select player —</option>
+          {players.map((p) => (
+            <option key={p.player_id || p.id} value={p.player_id || p.id}>
+              {p.player_name || p.name || `Player #${p.player_id || p.id}`}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {asset.asset_type === 'DRAFT_PICK' && (
+        <div className="flex gap-2 flex-1">
+          <input
+            type="number"
+            placeholder="Pick ID"
+            className="flex-1 rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+            value={asset.draft_pick_id || ''}
+            min="1"
+            onChange={(e) => onChange({ ...asset, draft_pick_id: e.target.value ? Number(e.target.value) : null })}
+          />
+          <input
+            type="number"
+            placeholder="Year"
+            className="w-24 rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+            value={asset.season_year || ''}
+            min="2020"
+            max="2040"
+            onChange={(e) => onChange({ ...asset, season_year: e.target.value ? Number(e.target.value) : null })}
+          />
+        </div>
+      )}
+
+      {asset.asset_type === 'DRAFT_DOLLARS' && (
+        <div className="flex items-center gap-1 flex-1">
+          <span className="text-sm text-slate-500 dark:text-slate-400">$</span>
+          <input
+            type="number"
+            placeholder="Amount"
+            className="flex-1 rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+            value={asset.amount || ''}
+            min="1"
+            onChange={(e) => onChange({ ...asset, amount: e.target.value ? Number(e.target.value) : '' })}
+          />
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onRemove}
+        className="mt-1 text-red-500 hover:text-red-400 focus:outline-none"
+        aria-label="Remove asset"
+      >
+        <FiTrash2 size={16} />
+      </button>
+    </div>
+  );
+}
+
+// ── Asset Panel (one side of the trade) ──────────────────────────────────────
+
+function AssetPanel({ title, teamId, roster, assets, onAddAsset, onRemoveAsset, onChangeAsset }) {
+  return (
+    <div className={cardSurface}>
+      <h3 className="text-base font-bold text-slate-900 dark:text-white mb-3">{title}</h3>
+      <div className="space-y-2">
+        {assets.map((a, i) => (
+          <AssetRow
+            key={i}
+            asset={a}
+            roster={roster}
+            onRemove={() => onRemoveAsset(i)}
+            onChange={(updated) => onChangeAsset(i, updated)}
+          />
+        ))}
+        {assets.length === 0 && (
+          <p className={`text-sm ${textMuted}`}>No assets added yet.</p>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onAddAsset}
+        className={`mt-3 ${buttonSecondary} flex items-center gap-2 text-sm`}
+        disabled={!teamId}
+      >
+        <FiPlus size={14} /> Add Asset
+      </button>
+    </div>
+  );
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
+
+const newAsset = () => ({ asset_type: 'PLAYER', player_id: null, draft_pick_id: null, season_year: null, amount: '' });
+
+export default function TradeBuilder() {
+  const leagueId = useActiveLeague();
+
+  const [teams, setTeams] = useState([]);
+  const [teamsLoading, setTeamsLoading] = useState(true);
+
+  const [teamBId, setTeamBId] = useState('');
+  const [rosterB, setRosterB] = useState([]);
+  const [rosterBLoading, setRosterBLoading] = useState(false);
+
+  // My roster (team A) loaded from /auth/me → team context
+  const myTeamId = localStorage.getItem('team_id') || localStorage.getItem('owner_id') || null;
+  const [rosterA, setRosterA] = useState([]);
+
+  const [assetsFromA, setAssetsFromA] = useState([]);
+  const [assetsFromB, setAssetsFromB] = useState([]);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // Load teams
+  useEffect(() => {
+    if (!leagueId) return;
+    setTeamsLoading(true);
+    fetchLeagueTeams(leagueId)
+      .then(setTeams)
+      .catch(() => setTeams([]))
+      .finally(() => setTeamsLoading(false));
+  }, [leagueId]);
+
+  // Load my roster
+  useEffect(() => {
+    if (!leagueId || !myTeamId) return;
+    fetchTeamRoster(leagueId, myTeamId).catch(() => []).then(setRosterA);
+  }, [leagueId, myTeamId]);
+
+  // Load team B roster when opponent selected
+  const loadRosterB = useCallback(async (tid) => {
+    if (!tid || !leagueId) { setRosterB([]); return; }
+    setRosterBLoading(true);
+    try {
+      setRosterB(await fetchTeamRoster(leagueId, tid));
+    } catch {
+      setRosterB([]);
+    } finally {
+      setRosterBLoading(false);
+    }
+  }, [leagueId]);
+
+  const handleTeamBChange = (tid) => {
+    setTeamBId(tid);
+    setAssetsFromB([]);
+    loadRosterB(tid);
+    setError('');
+  };
+
+  // Asset mutations — side A
+  const addA = () => setAssetsFromA((p) => [...p, newAsset()]);
+  const removeA = (i) => setAssetsFromA((p) => p.filter((_, idx) => idx !== i));
+  const changeA = (i, v) => setAssetsFromA((p) => p.map((a, idx) => idx === i ? v : a));
+
+  // Asset mutations — side B
+  const addB = () => setAssetsFromB((p) => [...p, newAsset()]);
+  const removeB = (i) => setAssetsFromB((p) => p.filter((_, idx) => idx !== i));
+  const changeB = (i, v) => setAssetsFromB((p) => p.map((a, idx) => idx === i ? v : a));
+
+  const validate = () => {
+    if (!leagueId) return 'No active league selected.';
+    if (!teamBId) return 'Please select a trade partner.';
+    if (assetsFromA.length === 0 && assetsFromB.length === 0) return 'Add at least one asset to the trade.';
+    for (const a of assetsFromA) {
+      if (a.asset_type === 'PLAYER' && !a.player_id) return 'Select a player for all your player assets.';
+      if (a.asset_type === 'DRAFT_PICK' && !a.draft_pick_id) return 'Enter a pick ID for all draft pick assets.';
+      if (a.asset_type === 'DRAFT_DOLLARS' && !a.amount) return 'Enter an amount for all draft dollar assets.';
+    }
+    for (const a of assetsFromB) {
+      if (a.asset_type === 'PLAYER' && !a.player_id) return 'Select a player for all opponent player assets.';
+      if (a.asset_type === 'DRAFT_PICK' && !a.draft_pick_id) return 'Enter a pick ID for all opponent draft pick assets.';
+      if (a.asset_type === 'DRAFT_DOLLARS' && !a.amount) return 'Enter an amount for all opponent draft dollar assets.';
+    }
+    return null;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    const validationError = validate();
+    if (validationError) { setError(validationError); return; }
+
+    setSubmitting(true);
+    try {
+      const buildAsset = (a) => {
+        const base = { asset_type: a.asset_type };
+        if (a.asset_type === 'PLAYER') return { ...base, player_id: a.player_id };
+        if (a.asset_type === 'DRAFT_PICK') return { ...base, draft_pick_id: a.draft_pick_id, season_year: a.season_year || null };
+        if (a.asset_type === 'DRAFT_DOLLARS') return { ...base, amount: Number(a.amount) };
+        return base;
+      };
+      await submitTrade(leagueId, {
+        team_b_id: Number(teamBId),
+        assets_from_a: assetsFromA.map(buildAsset),
+        assets_from_b: assetsFromB.map(buildAsset),
+      });
+      setSuccess('Trade submitted! It is now pending commissioner review.');
+      setAssetsFromA([]);
+      setAssetsFromB([]);
+      setTeamBId('');
+      setRosterB([]);
+    } catch (err) {
+      const d = err?.response?.data?.detail;
+      setError(typeof d === 'string' ? d : 'Failed to submit trade. Check your assets and try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <PageTemplate
+      title="Trade Builder"
+      subtitle="Propose a trade with another team. Your commissioner will review it."
+      actions={
+        <Link to="/team" className={`${buttonSecondary} gap-2 px-3 py-2 text-sm no-underline`}>
+          <FiChevronLeft /> Back
+        </Link>
+      }
+    >
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Trade partner selector */}
+        <div className={cardSurface}>
+          <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-4">Trade Partner</h2>
+          {teamsLoading ? (
+            <LoadingState />
+          ) : teams.length === 0 ? (
+            <EmptyState message="No teams found in this league." />
+          ) : (
+            <div>
+              <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Select opponent team
+              </label>
+              <select
+                className={`${inputBase} max-w-xs`}
+                value={teamBId}
+                onChange={(e) => handleTeamBChange(e.target.value)}
+              >
+                <option value="">— choose a team —</option>
+                {teams
+                  .filter((t) => String(t.owner_id || t.id) !== String(myTeamId))
+                  .map((t) => (
+                    <option key={t.owner_id || t.id} value={t.owner_id || t.id}>
+                      {t.team_name || t.owner_name || `Team #${t.owner_id || t.id}`}
+                    </option>
+                  ))}
+              </select>
+            </div>
+          )}
+        </div>
+
+        {/* Asset panels */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              You give (Team A)
+            </p>
+            <AssetPanel
+              title="Your Assets"
+              teamId={myTeamId}
+              roster={rosterA}
+              assets={assetsFromA}
+              onAddAsset={addA}
+              onRemoveAsset={removeA}
+              onChangeAsset={changeA}
+            />
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              You receive (Team B)
+            </p>
+            {rosterBLoading ? (
+              <LoadingState />
+            ) : (
+              <AssetPanel
+                title="Their Assets"
+                teamId={teamBId}
+                roster={rosterB}
+                assets={assetsFromB}
+                onAddAsset={addB}
+                onRemoveAsset={removeB}
+                onChangeAsset={changeB}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Trade summary */}
+        {(assetsFromA.length > 0 || assetsFromB.length > 0) && (
+          <div className={cardSurface}>
+            <h3 className="text-base font-bold text-slate-900 dark:text-white mb-3">Trade Summary</h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">You Give</p>
+                {assetsFromA.length === 0 ? (
+                  <p className={`text-sm ${textMuted}`}>Nothing</p>
+                ) : (
+                  <ul className="space-y-0.5">
+                    {assetsFromA.map((a, i) => <li key={i} className="text-sm text-slate-700 dark:text-slate-300">{assetLabel(a)}</li>)}
+                  </ul>
+                )}
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">You Receive</p>
+                {assetsFromB.length === 0 ? (
+                  <p className={`text-sm ${textMuted}`}>Nothing</p>
+                ) : (
+                  <ul className="space-y-0.5">
+                    {assetsFromB.map((a, i) => <li key={i} className="text-sm text-slate-700 dark:text-slate-300">{assetLabel(a)}</li>)}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Feedback */}
+        {error && (
+          <div className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="rounded-lg border border-green-400/30 bg-green-500/10 px-3 py-2 text-sm text-green-300">
+            {success}
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            className={buttonPrimary}
+            disabled={submitting || !teamBId}
+          >
+            {submitting ? 'Submitting…' : 'Submit Trade Proposal'}
+          </button>
+        </div>
+      </form>
+    </PageTemplate>
+  );
+}

--- a/frontend/src/pages/commissioner/ManageTrades.jsx
+++ b/frontend/src/pages/commissioner/ManageTrades.jsx
@@ -19,7 +19,6 @@ import {
   tableCell,
   textMuted,
   layerModal,
-  layerBackdrop,
 } from '@utils/uiStandards';
 import {
   fetchPendingTrades,
@@ -141,7 +140,7 @@ function TradeWindowSettings({ leagueId }) {
           {windowBanner.label}
           {settings?.trade_start_at && (
             <span className="ml-2 font-normal opacity-80">
-              {fmtDt(settings.trade_start_at)} → {fmtDt(settings.trade_end_at) || 'no end set'}
+              {fmtDt(settings.trade_start_at)}  {settings.trade_end_at ? fmtDt(settings.trade_end_at) : 'no end set'}
             </span>
           )}
         </div>
@@ -243,6 +242,8 @@ function TradeDetailDrawer({ leagueId, tradeId, onClose, onAction }) {
 
   useEffect(() => {
     if (!tradeId) return;
+    setComments('');
+    setActionMsg('');
     setLoading(true);
     Promise.all([
       fetchTradeDetail(leagueId, tradeId).catch(() => null),
@@ -275,7 +276,7 @@ function TradeDetailDrawer({ leagueId, tradeId, onClose, onAction }) {
 
   return (
     <>
-      <div className={`fixed inset-0 bg-black/50 ${layerBackdrop}`} onClick={onClose} aria-hidden="true" />
+      <div className={`fixed inset-0 bg-black/50 ${layerModal}`} onClick={onClose} aria-hidden="true" />
       <div
         className={`fixed right-0 top-0 h-full w-full max-w-lg overflow-y-auto bg-white dark:bg-slate-900 shadow-2xl ${layerModal} flex flex-col`}
         role="dialog"
@@ -331,7 +332,9 @@ function TradeDetailDrawer({ leagueId, tradeId, onClose, onAction }) {
                     {history.map((ev, i) => (
                       <li key={i} className="text-xs text-slate-600 dark:text-slate-400 flex items-start gap-2 flex-wrap">
                         <span className="font-semibold text-slate-700 dark:text-slate-300">{ev.event_type}</span>
-                        {ev.commissioner_comments && <span className="italic">"{ev.commissioner_comments}"</span>}
+                        {(ev.comment || ev.commissioner_comments) && (
+                          <span className="italic">"{ev.comment || ev.commissioner_comments}"</span>
+                        )}
                         <span className="ml-auto shrink-0">{fmtDt(ev.created_at)}</span>
                       </li>
                     ))}

--- a/frontend/src/pages/commissioner/ManageTrades.jsx
+++ b/frontend/src/pages/commissioner/ManageTrades.jsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import apiClient from '@api/client';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
+import { FiChevronLeft, FiX, FiCheck, FiXCircle } from 'react-icons/fi';
 import { useActiveLeague } from '@context/LeagueContext';
-import { FiChevronLeft } from 'react-icons/fi';
 import PageTemplate from '@components/layout/PageTemplate';
 import { EmptyState, LoadingState } from '@components/common/AsyncState';
 import {
@@ -16,45 +15,386 @@ import {
   buttonPrimary,
   buttonSecondary,
   cardSurface,
+  inputBase,
   tableCell,
+  textMuted,
+  layerModal,
+  layerBackdrop,
 } from '@utils/uiStandards';
+import {
+  fetchPendingTrades,
+  fetchTradeDetail,
+  fetchTradeHistory,
+  fetchTradeWindowSettings,
+  saveTradeWindowSettings,
+  approveTrade,
+  rejectTrade,
+} from '@api/tradesApi';
 
 /* ignore-breakpoints */
 
-const normalizeTrades = (payload) => {
-  if (Array.isArray(payload)) return payload;
-  if (Array.isArray(payload?.trades)) return payload.trades;
-  if (Array.isArray(payload?.items)) return payload.items;
-  return [];
-};
+const TIMEZONES = [
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Phoenix',
+  'America/Anchorage',
+  'Pacific/Honolulu',
+  'UTC',
+];
 
 const summarizeAssets = (assets = []) => {
   if (!Array.isArray(assets) || assets.length === 0) return 'None';
   return assets
-    .map((asset) => {
-      if (asset.asset_type === 'PLAYER') {
-        return asset.player_name || `Player #${asset.player_id}`;
-      }
-      if (asset.asset_type === 'DRAFT_PICK') {
-        return `Pick #${asset.draft_pick_id}${asset.season_year ? ` (${asset.season_year})` : ''}`;
-      }
-      if (asset.asset_type === 'DRAFT_DOLLARS') {
-        return `$${Number(asset.amount || 0)}`;
-      }
-      return asset.asset_type;
+    .map((a) => {
+      if (a.asset_type === 'PLAYER') return a.player_name || `Player #${a.player_id}`;
+      if (a.asset_type === 'DRAFT_PICK')
+        return `Pick #${a.draft_pick_id}${a.season_year ? ` (${a.season_year})` : ''}`;
+      if (a.asset_type === 'DRAFT_DOLLARS') return `$${Number(a.amount || 0)}`;
+      return a.asset_type;
     })
     .join(', ');
 };
+
+const fmtDt = (iso) => {
+  if (!iso) return '—';
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+};
+
+// ── Trade Window Settings Panel ───────────────────────────────────────────────
+
+function TradeWindowSettings({ leagueId }) {
+  const [settings, setSettings] = useState(null);
+  const [form, setForm] = useState({ trade_start_at: '', trade_end_at: '', timezone: 'America/New_York', is_active: false });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    if (!leagueId) return;
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchTradeWindowSettings(leagueId);
+      setSettings(data);
+      setForm({
+        trade_start_at: data.trade_start_at ? data.trade_start_at.slice(0, 16) : '',
+        trade_end_at: data.trade_end_at ? data.trade_end_at.slice(0, 16) : '',
+        timezone: data.timezone || 'America/New_York',
+        is_active: Boolean(data.is_active),
+      });
+    } catch {
+      setError('Trade window settings unavailable (feature may not be enabled yet).');
+    } finally {
+      setLoading(false);
+    }
+  }, [leagueId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleChange = (field, value) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setMessage('');
+    setError('');
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    setMessage('');
+    setError('');
+    if (form.trade_start_at && form.trade_end_at && form.trade_start_at >= form.trade_end_at) {
+      setError('Start date must be before end date.');
+      return;
+    }
+    setSaving(true);
+    try {
+      await saveTradeWindowSettings(leagueId, {
+        trade_start_at: form.trade_start_at || null,
+        trade_end_at: form.trade_end_at || null,
+        timezone: form.timezone,
+        is_active: form.is_active,
+      });
+      setMessage('Trade window settings saved.');
+      load();
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === 'string' ? detail : 'Failed to save settings.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const windowBanner = settings
+    ? settings.is_active
+      ? { cls: 'bg-green-500/10 border-green-400/30 text-green-300', label: 'Trade window is OPEN' }
+      : { cls: 'bg-red-500/10 border-red-400/30 text-red-300', label: 'Trade window is CLOSED' }
+    : null;
+
+  return (
+    <div className={cardSurface}>
+      <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-4">Trade Window Configuration</h2>
+
+      {windowBanner && (
+        <div className={`mb-4 rounded-lg border px-3 py-2 text-sm font-semibold ${windowBanner.cls}`}>
+          {windowBanner.label}
+          {settings?.trade_start_at && (
+            <span className="ml-2 font-normal opacity-80">
+              {fmtDt(settings.trade_start_at)} → {fmtDt(settings.trade_end_at) || 'no end set'}
+            </span>
+          )}
+        </div>
+      )}
+
+      {loading && <LoadingState />}
+      {!loading && error && (
+        <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-300">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && (
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Trade Window Start
+              </label>
+              <input
+                type="datetime-local"
+                className={inputBase}
+                value={form.trade_start_at}
+                onChange={(e) => handleChange('trade_start_at', e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Trade Window End
+              </label>
+              <input
+                type="datetime-local"
+                className={inputBase}
+                value={form.trade_end_at}
+                onChange={(e) => handleChange('trade_end_at', e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Timezone
+              </label>
+              <select
+                className={inputBase}
+                value={form.timezone}
+                onChange={(e) => handleChange('timezone', e.target.value)}
+              >
+                {TIMEZONES.map((tz) => (
+                  <option key={tz} value={tz}>{tz}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-3 pt-5">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={form.is_active}
+                onClick={() => handleChange('is_active', !form.is_active)}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500/40 ${form.is_active ? 'bg-cyan-600' : 'bg-slate-600'}`}
+              >
+                <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${form.is_active ? 'translate-x-6' : 'translate-x-1'}`} />
+              </button>
+              <span className="text-sm text-slate-700 dark:text-slate-300">
+                {form.is_active ? 'Window active (trades allowed)' : 'Window inactive (trades blocked)'}
+              </span>
+            </div>
+          </div>
+
+          {message && (
+            <div className="rounded-lg border border-green-400/30 bg-green-500/10 px-3 py-2 text-sm text-green-300">
+              {message}
+            </div>
+          )}
+          {error && (
+            <div className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <button type="submit" className={buttonPrimary} disabled={saving}>
+              {saving ? 'Saving…' : 'Save Trade Window'}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+// ── Trade Detail Drawer ───────────────────────────────────────────────────────
+
+function TradeDetailDrawer({ leagueId, tradeId, onClose, onAction }) {
+  const [detail, setDetail] = useState(null);
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [comments, setComments] = useState('');
+  const [actionMsg, setActionMsg] = useState('');
+  const [acting, setActing] = useState(false);
+
+  useEffect(() => {
+    if (!tradeId) return;
+    setLoading(true);
+    Promise.all([
+      fetchTradeDetail(leagueId, tradeId).catch(() => null),
+      fetchTradeHistory(leagueId, tradeId).catch(() => []),
+    ]).then(([d, h]) => {
+      setDetail(d);
+      setHistory(Array.isArray(h) ? h : []);
+      setLoading(false);
+    });
+  }, [leagueId, tradeId]);
+
+  const handleAction = async (action) => {
+    setActionMsg('');
+    setActing(true);
+    try {
+      if (action === 'approve') {
+        await approveTrade(leagueId, tradeId, comments);
+      } else {
+        await rejectTrade(leagueId, tradeId, comments);
+      }
+      onAction(tradeId, action);
+      onClose();
+    } catch (err) {
+      const d = err?.response?.data?.detail;
+      setActionMsg(typeof d === 'string' ? d : `Failed to ${action} trade.`);
+    } finally {
+      setActing(false);
+    }
+  };
+
+  return (
+    <>
+      <div className={`fixed inset-0 bg-black/50 ${layerBackdrop}`} onClick={onClose} aria-hidden="true" />
+      <div
+        className={`fixed right-0 top-0 h-full w-full max-w-lg overflow-y-auto bg-white dark:bg-slate-900 shadow-2xl ${layerModal} flex flex-col`}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Trade Detail"
+      >
+        <div className="flex items-center justify-between border-b border-slate-300 dark:border-slate-800 px-4 py-3">
+          <h2 className="text-lg font-bold text-slate-900 dark:text-white">Trade Detail</h2>
+          <button type="button" onClick={onClose} className={buttonSecondary} aria-label="Close drawer">
+            <FiX />
+          </button>
+        </div>
+
+        <div className="flex-1 p-4 space-y-5">
+          {loading && <LoadingState />}
+          {!loading && !detail && <EmptyState message="Trade details unavailable." />}
+
+          {!loading && detail && (
+            <>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">Team A</p>
+                  <p className="text-sm font-medium text-slate-900 dark:text-white">{detail.team_a_name || `Team ${detail.team_a_id}`}</p>
+                  <p className={`text-xs mt-1 ${textMuted}`}>Offers: {summarizeAssets(detail.assets_from_a)}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-1">Team B</p>
+                  <p className="text-sm font-medium text-slate-900 dark:text-white">{detail.team_b_name || `Team ${detail.team_b_id}`}</p>
+                  <p className={`text-xs mt-1 ${textMuted}`}>Offers: {summarizeAssets(detail.assets_from_b)}</p>
+                </div>
+              </div>
+
+              {[{ label: 'Assets from Team A', items: detail.assets_from_a }, { label: 'Assets from Team B', items: detail.assets_from_b }].map(({ label, items }) => (
+                <div key={label}>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">{label}</p>
+                  <ul className="space-y-1">
+                    {(items || []).map((a, i) => (
+                      <li key={i} className="text-sm text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded px-2 py-1">
+                        {a.asset_type === 'PLAYER' && (a.player_name || `Player #${a.player_id}`)}
+                        {a.asset_type === 'DRAFT_PICK' && `Pick #${a.draft_pick_id}${a.season_year ? ` (${a.season_year})` : ''}`}
+                        {a.asset_type === 'DRAFT_DOLLARS' && `$${Number(a.amount || 0)} draft dollars`}
+                      </li>
+                    ))}
+                    {(!items || items.length === 0) && <li className={`text-sm ${textMuted}`}>None</li>}
+                  </ul>
+                </div>
+              ))}
+
+              {history.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">Audit History</p>
+                  <ul className="space-y-1">
+                    {history.map((ev, i) => (
+                      <li key={i} className="text-xs text-slate-600 dark:text-slate-400 flex items-start gap-2 flex-wrap">
+                        <span className="font-semibold text-slate-700 dark:text-slate-300">{ev.event_type}</span>
+                        {ev.commissioner_comments && <span className="italic">"{ev.commissioner_comments}"</span>}
+                        <span className="ml-auto shrink-0">{fmtDt(ev.created_at)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div>
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Commissioner Comment (optional)
+                </label>
+                <textarea
+                  rows={3}
+                  className={inputBase}
+                  placeholder="Add a comment visible in the trade history…"
+                  value={comments}
+                  onChange={(e) => setComments(e.target.value)}
+                />
+              </div>
+
+              {actionMsg && (
+                <div className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+                  {actionMsg}
+                </div>
+              )}
+
+              <div className="flex gap-3">
+                <button
+                  type="button"
+                  className={`${buttonPrimary} flex items-center gap-2`}
+                  disabled={acting}
+                  onClick={() => handleAction('approve')}
+                >
+                  <FiCheck /> {acting ? 'Processing…' : 'Approve Trade'}
+                </button>
+                <button
+                  type="button"
+                  className={`${buttonDanger} flex items-center gap-2`}
+                  disabled={acting}
+                  onClick={() => handleAction('reject')}
+                >
+                  <FiXCircle /> {acting ? 'Processing…' : 'Reject Trade'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Main Page ─────────────────────────────────────────────────────────────────
 
 export default function ManageTrades() {
   const leagueId = useActiveLeague();
   const [trades, setTrades] = useState([]);
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState('');
-  const [actionComments, setActionComments] = useState({});
+  const [selectedTradeId, setSelectedTradeId] = useState(null);
 
-  const fetchTrades = async (currentLeagueId) => {
-    if (!currentLeagueId) {
+  const loadTrades = useCallback(async () => {
+    if (!leagueId) {
       setTrades([]);
       setLoading(false);
       setMessage('No active league selected.');
@@ -63,129 +403,75 @@ export default function ManageTrades() {
     setLoading(true);
     setMessage('');
     try {
-      const res = await apiClient.get(`/trades/leagues/${currentLeagueId}/pending-v2`);
-      setTrades(normalizeTrades(res.data));
+      setTrades(await fetchPendingTrades(leagueId));
     } catch {
       setTrades([]);
-      setMessage('Failed to load trades');
+      setMessage('Failed to load pending trades.');
     } finally {
       setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    fetchTrades(leagueId);
   }, [leagueId]);
 
-  const handleAction = async (tradeId, action) => {
-    setMessage('');
-    try {
-      if (!leagueId) {
-        setMessage('Unable to determine league context.');
-        return;
-      }
-      const comments = actionComments[tradeId] || '';
-      const endpoint =
-        action === 'approve'
-          ? `/trades/leagues/${leagueId}/${tradeId}/approve-v2`
-          : `/trades/leagues/${leagueId}/${tradeId}/reject-v2`;
-      await apiClient.post(endpoint, {
-        commissioner_comments: comments,
-      });
-      setTrades((prevTrades) => prevTrades.filter((t) => t.id !== tradeId));
-      setActionComments((prev) => {
-        const next = { ...prev };
-        delete next[tradeId];
-        return next;
-      });
-      const actionLabel = action === 'approve' ? 'approved' : 'rejected';
-      setMessage(`Trade ${actionLabel} successfully!`);
-    } catch {
-      setMessage(`Failed to ${action} trade`);
-    }
+  useEffect(() => { loadTrades(); }, [loadTrades]);
+
+  const handleAction = (tradeId, action) => {
+    setTrades((prev) => prev.filter((t) => t.id !== tradeId));
+    setMessage(`Trade ${action === 'approve' ? 'approved' : 'rejected'} successfully.`);
   };
 
   return (
     <PageTemplate
       title="Manage Trades"
-      subtitle="View and review pending trades."
+      subtitle="Configure the trade window and review pending trades."
       actions={
-        <Link
-          to="/commissioner"
-          className={`${buttonSecondary} gap-2 px-3 py-2 text-sm no-underline`}
-        >
+        <Link to="/commissioner" className={`${buttonSecondary} gap-2 px-3 py-2 text-sm no-underline`}>
           <FiChevronLeft /> Back
         </Link>
       }
     >
+      {/* Trade window config + open/closed status banner */}
+      <TradeWindowSettings leagueId={leagueId} />
 
-      {message && (
-        <div className="rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-300">
-          {message}
-        </div>
-      )}
-
+      {/* Pending queue */}
       <div className={cardSurface}>
-        <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-4">
-          Pending Trades
-        </h2>
+        <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-4">Pending Trades</h2>
+
+        {message && (
+          <div className="mb-4 rounded-lg border border-cyan-400/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-300">
+            {message}
+          </div>
+        )}
+
         {loading ? (
           <LoadingState />
-        ) : !Array.isArray(trades) || trades.length === 0 ? (
+        ) : !trades.length ? (
           <EmptyState message="No pending trades." />
         ) : (
           <StandardTableContainer>
             <StandardTable>
               <StandardTableHead
                 headers={[
-                  { key: 'from', label: 'From Team' },
-                  { key: 'to', label: 'To Team' },
-                  { key: 'assetsFromA', label: 'Assets From A' },
-                  { key: 'assetsFromB', label: 'Assets From B' },
-                  { key: 'comments', label: 'Comments' },
+                  { key: 'teamA', label: 'Team A' },
+                  { key: 'teamB', label: 'Team B' },
+                  { key: 'offersA', label: 'Offers (A)' },
+                  { key: 'offersB', label: 'Offers (B)' },
                   { key: 'actions', label: 'Actions' },
                 ]}
               />
               <tbody>
                 {trades.map((trade) => (
                   <StandardTableRow key={trade.id}>
-                    <td className={tableCell}>{trade.team_a_name || 'Unknown Team A'}</td>
-                    <td className={tableCell}>{trade.team_b_name || 'Unknown Team B'}</td>
+                    <td className={tableCell}>{trade.team_a_name || 'Team A'}</td>
+                    <td className={tableCell}>{trade.team_b_name || 'Team B'}</td>
+                    <td className={tableCell}>{summarizeAssets(trade.assets_from_a)}</td>
+                    <td className={tableCell}>{summarizeAssets(trade.assets_from_b)}</td>
                     <td className={tableCell}>
-                      {summarizeAssets(trade.assets_from_a)}
-                    </td>
-                    <td className={tableCell}>
-                      {summarizeAssets(trade.assets_from_b)}
-                    </td>
-                    <td className={tableCell}>
-                      <textarea
-                        rows={2}
-                        aria-label={`Commissioner comments for trade ${trade.id}`}
-                        className="w-full rounded border border-slate-600 bg-slate-900 px-2 py-1 text-xs text-slate-200"
-                        placeholder="Optional commissioner comment"
-                        value={actionComments[trade.id] || ''}
-                        onChange={(e) =>
-                          setActionComments((prev) => ({
-                            ...prev,
-                            [trade.id]: e.target.value,
-                          }))
-                        }
-                      />
-                    </td>
-                    <td className={`${tableCell} space-x-2`}>
                       <button
                         type="button"
-                        className={buttonPrimary}
-                        onClick={() => handleAction(trade.id, 'approve')}
+                        className={buttonSecondary}
+                        onClick={() => setSelectedTradeId(trade.id)}
                       >
-                        Approve
-                      </button>
-                      <button
-                        type="button"
-                        className={buttonDanger}
-                        onClick={() => handleAction(trade.id, 'reject')}
-                      >
-                        Reject
+                        Review
                       </button>
                     </td>
                   </StandardTableRow>
@@ -195,7 +481,16 @@ export default function ManageTrades() {
           </StandardTableContainer>
         )}
       </div>
+
+      {/* Detail drawer */}
+      {selectedTradeId && (
+        <TradeDetailDrawer
+          leagueId={leagueId}
+          tradeId={selectedTradeId}
+          onClose={() => setSelectedTradeId(null)}
+          onAction={handleAction}
+        />
+      )}
     </PageTemplate>
   );
 }
-// ...existing code...


### PR DESCRIPTION
## Summary

Completes all three frontend phases of the Trade System epic (#343).

## Changes

### Phase 2 — Trade Timeline Config UI (#348)
- `TradeWindowSettings` panel added to `ManageTrades` commissioner page
- GET/PUT `/trades/leagues/{id}/settings/trade-window` fully wired
- `datetime-local` inputs for trade start/end, timezone dropdown (8 US + UTC)
- Toggle switch for `is_active` flag
- Open/closed status banner visible to all page visitors
- Client-side validation: start must precede end; graceful degradation if endpoint not enabled

### Phase 3 — Trade Builder UI (#350)
- New `TradeBuilder` page at `/trades/submit`, registered in App.jsx and Sidebar
- Multi-asset composer: PLAYER / DRAFT_PICK / DRAFT_DOLLARS per side
- Opponent selector loads their roster for PLAYER dropdowns
- Live validation before submit: partner required, all asset fields complete
- Trade summary card (give / receive) before committing
- Wired to `POST /trades/leagues/{id}/submit-v2`; success/error states with actionable messaging

### Phase 4 — Commissioner Review Queue (#352)
- `TradeDetailDrawer` slide-over replaces inline approve/reject buttons
- Full asset breakdown (A and B sides) with per-asset line items
- Audit history loaded from `GET /trades/{id}/history-v2` shown in chronological order
- Commissioner comment textarea; approve/reject wired to API inside drawer
- Trade removed from queue on successful action

### Supporting
- New `frontend/src/api/tradesApi.js` — centralises all trade API calls

Closes #348
Closes #350
Closes #352
