### PR TITLE
docs: sync Issue #81 status after PR Notes audit

### DIFF
--- a/docs/ISSUE_STATUS.md
+++ b/docs/ISSUE_STATUS.md
@@ -5,7 +5,7 @@
 - [x] Issue #56: Create draft value database for fantasy football draft purposes
 - [x] Issue #57: Create APIs to pull in draft value information from ESPN, Yahoo, Draftsharks
 # GitHub Issues Status Report
-**Date:** March 14, 2026  
+**Date:** April 26, 2026  
 **Branch:** main
 
 ---

--- a/docs/ISSUE_STATUS.md
+++ b/docs/ISSUE_STATUS.md
@@ -14,7 +14,7 @@
 
 - **Issue #81**: `Phase 1: Raspberry Pi OS Setup`
   - **Implementation Status:** Resolved in current branch via Raspberry Pi Phase 1 runbook updates
-  - **GitHub Status:** Pending close-out comment / closure
+  - **GitHub Status:** Closed (March 19, 2026) with close-out comment
   - **Close-Out Notes:** Captured in `docs/PR_NOTES.md` under `Issue #81 Close-Out Notes`
 
 - **Issue #131**: `Create Dedicated Draft Day Analyzer Page + Fix Advisor & Simulation Failures`


### PR DESCRIPTION
## Summary

Syncs stale issue-status metadata after PR Notes review.

- Updates `docs/ISSUE_STATUS.md` entry for Issue #81 to reflect actual GitHub status.
- Replaces stale "Pending close-out" text with closed status/date (March 19, 2026).

## Why

During PR Notes fix-up, Issue #81 was already closed on GitHub, but the status report still listed it as pending closure.

## Validation

- Verified with `gh issue view 81 --json state,closedAt`
- Confirmed all other PR_NOTES-targeted issues are already closed except carryover Issue #290 (intentionally open).
