### PR TITLE
feat: cross-platform local startup scripts with canonical docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,6 +47,7 @@ CI
 - [ ] Linter/formatters pass locally (pre-commit)
 - [ ] No secrets or large binaries added
 - [ ] CI checks are green (or explained why not)
+- [ ] If startup behavior/docs changed: Linux and Windows startup parity was validated (or not applicable with rationale)
 
 ## Security checklist (required for auth, API, infra, or dependency changes)
 - [ ] Inputs are validated server-side and errors do not leak sensitive internals

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 frontend/dist/
+.dev-backend.log
 frontend/build/
 .npm
 .yarn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,18 @@ hit breakpoints as you interact with the UI.
      - Update `docs/ISSUE_STATUS.md` with implementation state and close-out note reference.
      - Reflect the transition in the PR `Issue Hygiene` section (`Closed`, `Pending close`, `Net new`).
 
+  12. **Cross-platform startup parity gate (required for dev startup/docs changes).**
+     - If a PR changes local startup behavior, startup scripts, or startup documentation,
+       validate Linux and Windows flows remain equivalent.
+     - Required scope for parity changes:
+       - update both [start-dev.sh](start-dev.sh) and [start-dev.ps1](start-dev.ps1), or
+         explicitly justify why one platform is unaffected
+       - update the single canonical startup section in [README.md](README.md)
+     - Required PR evidence:
+       - Linux validation note (script run or syntax check)
+       - Windows validation note (PowerShell parse/run, or explicit environment limitation)
+     - PRs that change startup behavior without parity verification should not be merged.
+
 ---
 
 By adhering to these standards, the frontend stops being a black box and

--- a/README.md
+++ b/README.md
@@ -78,6 +78,41 @@ For the full endpoint-level matrix (including notes and gaps), see [API_PAGE_MAT
 
 ---
 
+## Local App Startup (Cross-Platform)
+
+Use the repo-root startup scripts as the canonical local development flow.
+They keep Linux and Windows behavior aligned:
+
+- validate required tooling
+- create `backend/.env` from `backend/.env.example` when missing
+- verify backend readiness at `/health`
+- start frontend only after backend is healthy
+- fail fast on backend port conflicts with actionable messaging
+
+Linux/macOS:
+
+```bash
+./start-dev.sh
+```
+
+Windows PowerShell:
+
+```powershell
+.\start-dev.ps1
+```
+
+Optional custom ports:
+
+```bash
+BACKEND_PORT=8001 FRONTEND_PORT=5174 ./start-dev.sh
+```
+
+```powershell
+$env:BACKEND_PORT = "8001"
+$env:FRONTEND_PORT = "5174"
+.\start-dev.ps1
+```
+
 Frontend testing & local run
 
 - Install dependencies and run dev server:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ They keep Linux and Windows behavior aligned:
 - start frontend only after backend is healthy
 - fail fast on backend port conflicts with actionable messaging
 
-Linux/macOS:
+Linux/WSL:
 
 ```bash
 ./start-dev.sh

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -68,8 +68,6 @@ function Resolve-BackendPython {
     exit 1
 }
 
-Register-EngineEvent PowerShell.Exiting -Action { Stop-BackendIfOwned } | Out-Null
-
 Require-Command "npm"
 
 Set-Location $ROOT_DIR
@@ -82,6 +80,10 @@ if (-not (Test-Path (Join-Path $ROOT_DIR "frontend"))) {
 $backendEnv = Join-Path $ROOT_DIR "backend/.env"
 $backendEnvExample = Join-Path $ROOT_DIR "backend/.env.example"
 if (-not (Test-Path $backendEnv)) {
+    if (-not (Test-Path $backendEnvExample)) {
+        Log "backend/.env.example not found. Cannot bootstrap backend/.env."
+        exit 1
+    }
     Log "backend/.env not found. Creating it from backend/.env.example."
     Copy-Item -Path $backendEnvExample -Destination $backendEnv
 }
@@ -95,58 +97,64 @@ if (Get-Command "pg_isready" -ErrorAction SilentlyContinue) {
         if ($LASTEXITCODE -eq 0) {
             Log "Postgres is reachable on 127.0.0.1:5432"
         } else {
-            Log "Postgres is not reachable on 127.0.0.1:5432 (continuing; backend may fail if DB is required)."
+            Log "Postgres is not reachable on 127.0.0.1:5432."
+            Log "Backend health requires DB connectivity, so startup will likely fail until Postgres is available."
         }
     } catch {
-        Log "Postgres check failed (continuing; backend may fail if DB is required)."
+        Log "Postgres check failed. Backend health requires DB connectivity, so startup will likely fail until Postgres is available."
     }
 } else {
     Log "pg_isready not found; skipping Postgres readiness check."
 }
 
-if (Test-Health $BACKEND_HEALTH_URL) {
-    Log "Backend already healthy at $BACKEND_HEALTH_URL"
-} else {
-    $portInUse = Get-NetTCPConnection -LocalPort ([int]$BACKEND_PORT) -State Listen -ErrorAction SilentlyContinue
-    if ($portInUse) {
-        Log "Port $BACKEND_PORT is already in use, but $BACKEND_HEALTH_URL is not healthy."
-        Log "Stop the process using port $BACKEND_PORT or set BACKEND_PORT to a different value."
-        exit 1
-    }
-
-    Log "Starting backend on $BACKEND_HOST`:$BACKEND_PORT"
-    $BACKEND_PROCESS = Start-Process -FilePath $BACKEND_PYTHON -ArgumentList @(
-        "-m", "uvicorn", "backend.main:app", "--host", "$BACKEND_HOST", "--port", "$BACKEND_PORT", "--reload"
-    ) -RedirectStandardOutput $BACKEND_LOG -RedirectStandardError $BACKEND_LOG -PassThru
-
-    Log "Backend PID: $($BACKEND_PROCESS.Id) (logs: $BACKEND_LOG)"
-
-    for ($i = 1; $i -le 60; $i++) {
-        if (Test-Health $BACKEND_HEALTH_URL) {
-            Log "Backend is healthy"
-            break
-        }
-
-        if ($BACKEND_PROCESS.HasExited) {
-            Log "Backend exited before becoming healthy. Last log lines:"
-            if (Test-Path $BACKEND_LOG) {
-                Get-Content $BACKEND_LOG -Tail 40
-            }
+try {
+    if (Test-Health $BACKEND_HEALTH_URL) {
+        Log "Backend already healthy at $BACKEND_HEALTH_URL"
+    } else {
+        $portInUse = Get-NetTCPConnection -LocalPort ([int]$BACKEND_PORT) -State Listen -ErrorAction SilentlyContinue
+        if ($portInUse) {
+            Log "Port $BACKEND_PORT is already in use, but $BACKEND_HEALTH_URL is not healthy."
+            Log "Stop the process using port $BACKEND_PORT or set BACKEND_PORT to a different value."
             exit 1
         }
 
-        Start-Sleep -Seconds 1
+        Log "Starting backend on $BACKEND_HOST`:$BACKEND_PORT"
+        $BACKEND_PROCESS = Start-Process -FilePath $BACKEND_PYTHON -ArgumentList @(
+            "-m", "uvicorn", "backend.main:app", "--host", "$BACKEND_HOST", "--port", "$BACKEND_PORT", "--reload"
+        ) -RedirectStandardOutput $BACKEND_LOG -RedirectStandardError $BACKEND_LOG -PassThru
 
-        if ($i -eq 60) {
-            Log "Timed out waiting for backend health at $BACKEND_HEALTH_URL"
-            if (Test-Path $BACKEND_LOG) {
-                Get-Content $BACKEND_LOG -Tail 40
+        Log "Backend PID: $($BACKEND_PROCESS.Id) (logs: $BACKEND_LOG)"
+
+        for ($i = 1; $i -le 60; $i++) {
+            if (Test-Health $BACKEND_HEALTH_URL) {
+                Log "Backend is healthy"
+                break
             }
-            exit 1
+
+            if ($BACKEND_PROCESS.HasExited) {
+                Log "Backend exited before becoming healthy. Last log lines:"
+                if (Test-Path $BACKEND_LOG) {
+                    Get-Content $BACKEND_LOG -Tail 40
+                }
+                exit 1
+            }
+
+            Start-Sleep -Seconds 1
+
+            if ($i -eq 60) {
+                Log "Timed out waiting for backend health at $BACKEND_HEALTH_URL"
+                if (Test-Path $BACKEND_LOG) {
+                    Get-Content $BACKEND_LOG -Tail 40
+                }
+                exit 1
+            }
         }
     }
+
+    Log "Starting frontend on port $FRONTEND_PORT"
+    Set-Location (Join-Path $ROOT_DIR "frontend")
+    & npm run dev -- --port "$FRONTEND_PORT" --strictPort
 }
-
-Log "Starting frontend on port $FRONTEND_PORT"
-Set-Location (Join-Path $ROOT_DIR "frontend")
-& npm run dev -- --port "$FRONTEND_PORT" --strictPort
+finally {
+    Stop-BackendIfOwned
+}

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -1,0 +1,122 @@
+$ErrorActionPreference = "Stop"
+
+$ROOT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
+$BACKEND_HOST = if ($env:BACKEND_HOST) { $env:BACKEND_HOST } else { "127.0.0.1" }
+$BACKEND_PORT = if ($env:BACKEND_PORT) { $env:BACKEND_PORT } else { "8000" }
+$FRONTEND_PORT = if ($env:FRONTEND_PORT) { $env:FRONTEND_PORT } else { "5173" }
+$BACKEND_HEALTH_URL = "http://$BACKEND_HOST`:$BACKEND_PORT/health"
+$BACKEND_LOG = Join-Path $ROOT_DIR ".dev-backend.log"
+$BACKEND_PROCESS = $null
+
+function Log([string]$message) {
+    $timestamp = Get-Date -Format "HH:mm:ss"
+    Write-Host "[$timestamp] $message"
+}
+
+function Require-Command([string]$name) {
+    if (-not (Get-Command $name -ErrorAction SilentlyContinue)) {
+        Log "Missing required command: $name"
+        exit 1
+    }
+}
+
+function Test-Health([string]$url) {
+    try {
+        $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 2
+        return $resp.StatusCode -ge 200 -and $resp.StatusCode -lt 300
+    } catch {
+        return $false
+    }
+}
+
+function Stop-BackendIfOwned {
+    if ($null -ne $BACKEND_PROCESS -and -not $BACKEND_PROCESS.HasExited) {
+        Log "Stopping backend (PID $($BACKEND_PROCESS.Id))"
+        try {
+            Stop-Process -Id $BACKEND_PROCESS.Id -Force -ErrorAction SilentlyContinue
+        } catch {
+            # no-op
+        }
+    }
+}
+
+Register-EngineEvent PowerShell.Exiting -Action { Stop-BackendIfOwned } | Out-Null
+
+Require-Command "npm"
+Require-Command "python"
+
+Set-Location $ROOT_DIR
+
+if (-not (Test-Path (Join-Path $ROOT_DIR "frontend"))) {
+    Log "frontend directory not found. Run this script from the repository root."
+    exit 1
+}
+
+$backendEnv = Join-Path $ROOT_DIR "backend/.env"
+$backendEnvExample = Join-Path $ROOT_DIR "backend/.env.example"
+if (-not (Test-Path $backendEnv)) {
+    Log "backend/.env not found. Creating it from backend/.env.example."
+    Copy-Item -Path $backendEnvExample -Destination $backendEnv
+}
+
+if (Get-Command "pg_isready" -ErrorAction SilentlyContinue) {
+    try {
+        & pg_isready -h 127.0.0.1 -p 5432 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Log "Postgres is reachable on 127.0.0.1:5432"
+        } else {
+            Log "Postgres is not reachable on 127.0.0.1:5432 (continuing; backend may fail if DB is required)."
+        }
+    } catch {
+        Log "Postgres check failed (continuing; backend may fail if DB is required)."
+    }
+} else {
+    Log "pg_isready not found; skipping Postgres readiness check."
+}
+
+if (Test-Health $BACKEND_HEALTH_URL) {
+    Log "Backend already healthy at $BACKEND_HEALTH_URL"
+} else {
+    $portInUse = Get-NetTCPConnection -LocalPort ([int]$BACKEND_PORT) -State Listen -ErrorAction SilentlyContinue
+    if ($portInUse) {
+        Log "Port $BACKEND_PORT is already in use, but $BACKEND_HEALTH_URL is not healthy."
+        Log "Stop the process using port $BACKEND_PORT or set BACKEND_PORT to a different value."
+        exit 1
+    }
+
+    Log "Starting backend on $BACKEND_HOST`:$BACKEND_PORT"
+    $BACKEND_PROCESS = Start-Process -FilePath "python" -ArgumentList @(
+        "-m", "uvicorn", "backend.main:app", "--host", "$BACKEND_HOST", "--port", "$BACKEND_PORT", "--reload"
+    ) -RedirectStandardOutput $BACKEND_LOG -RedirectStandardError $BACKEND_LOG -PassThru
+
+    Log "Backend PID: $($BACKEND_PROCESS.Id) (logs: $BACKEND_LOG)"
+
+    for ($i = 1; $i -le 60; $i++) {
+        if (Test-Health $BACKEND_HEALTH_URL) {
+            Log "Backend is healthy"
+            break
+        }
+
+        if ($BACKEND_PROCESS.HasExited) {
+            Log "Backend exited before becoming healthy. Last log lines:"
+            if (Test-Path $BACKEND_LOG) {
+                Get-Content $BACKEND_LOG -Tail 40
+            }
+            exit 1
+        }
+
+        Start-Sleep -Seconds 1
+
+        if ($i -eq 60) {
+            Log "Timed out waiting for backend health at $BACKEND_HEALTH_URL"
+            if (Test-Path $BACKEND_LOG) {
+                Get-Content $BACKEND_LOG -Tail 40
+            }
+            exit 1
+        }
+    }
+}
+
+Log "Starting frontend on port $FRONTEND_PORT"
+Set-Location (Join-Path $ROOT_DIR "frontend")
+& npm run dev -- --port "$FRONTEND_PORT" --strictPort

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -4,7 +4,9 @@ $ROOT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 $BACKEND_HOST = if ($env:BACKEND_HOST) { $env:BACKEND_HOST } else { "127.0.0.1" }
 $BACKEND_PORT = if ($env:BACKEND_PORT) { $env:BACKEND_PORT } else { "8000" }
 $FRONTEND_PORT = if ($env:FRONTEND_PORT) { $env:FRONTEND_PORT } else { "5173" }
-$BACKEND_HEALTH_URL = "http://$BACKEND_HOST`:$BACKEND_PORT/health"
+# Always probe 127.0.0.1 so the health check works even when BACKEND_HOST is 0.0.0.0
+$BACKEND_HEALTH_HOST = if ($env:BACKEND_HEALTH_HOST) { $env:BACKEND_HEALTH_HOST } else { "127.0.0.1" }
+$BACKEND_HEALTH_URL = "http://$BACKEND_HEALTH_HOST`:$BACKEND_PORT/health"
 $BACKEND_LOG = Join-Path $ROOT_DIR ".dev-backend.log"
 $BACKEND_PROCESS = $null
 $BACKEND_PYTHON = $null
@@ -23,7 +25,8 @@ function Require-Command([string]$name) {
 
 function Test-Health([string]$url) {
     try {
-        $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -TimeoutSec 2
+        # -UseBasicParsing is not supported in PowerShell 7+; use Invoke-WebRequest without it
+        $resp = Invoke-WebRequest -Uri $url -TimeoutSec 2
         return $resp.StatusCode -ge 200 -and $resp.StatusCode -lt 300
     } catch {
         return $false

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -7,6 +7,7 @@ $FRONTEND_PORT = if ($env:FRONTEND_PORT) { $env:FRONTEND_PORT } else { "5173" }
 $BACKEND_HEALTH_URL = "http://$BACKEND_HOST`:$BACKEND_PORT/health"
 $BACKEND_LOG = Join-Path $ROOT_DIR ".dev-backend.log"
 $BACKEND_PROCESS = $null
+$BACKEND_PYTHON = $null
 
 function Log([string]$message) {
     $timestamp = Get-Date -Format "HH:mm:ss"
@@ -40,10 +41,36 @@ function Stop-BackendIfOwned {
     }
 }
 
+function Resolve-BackendPython {
+    $candidates = @(
+        (Join-Path $ROOT_DIR "backend/venv/Scripts/python.exe"),
+        (Join-Path $ROOT_DIR ".venv/Scripts/python.exe")
+    )
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            & $candidate -c "import fastapi, uvicorn" *> $null
+            if ($LASTEXITCODE -eq 0) {
+                return $candidate
+            }
+        }
+    }
+
+    if (Get-Command "python" -ErrorAction SilentlyContinue) {
+        & python -c "import fastapi, uvicorn" *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return "python"
+        }
+    }
+
+    Log "Could not find a Python interpreter with fastapi and uvicorn installed."
+    Log "Install backend dependencies in backend/venv or .venv, then retry."
+    exit 1
+}
+
 Register-EngineEvent PowerShell.Exiting -Action { Stop-BackendIfOwned } | Out-Null
 
 Require-Command "npm"
-Require-Command "python"
 
 Set-Location $ROOT_DIR
 
@@ -58,6 +85,9 @@ if (-not (Test-Path $backendEnv)) {
     Log "backend/.env not found. Creating it from backend/.env.example."
     Copy-Item -Path $backendEnvExample -Destination $backendEnv
 }
+
+$BACKEND_PYTHON = Resolve-BackendPython
+Log "Using backend Python: $BACKEND_PYTHON"
 
 if (Get-Command "pg_isready" -ErrorAction SilentlyContinue) {
     try {
@@ -85,7 +115,7 @@ if (Test-Health $BACKEND_HEALTH_URL) {
     }
 
     Log "Starting backend on $BACKEND_HOST`:$BACKEND_PORT"
-    $BACKEND_PROCESS = Start-Process -FilePath "python" -ArgumentList @(
+    $BACKEND_PROCESS = Start-Process -FilePath $BACKEND_PYTHON -ArgumentList @(
         "-m", "uvicorn", "backend.main:app", "--host", "$BACKEND_HOST", "--port", "$BACKEND_PORT", "--reload"
     ) -RedirectStandardOutput $BACKEND_LOG -RedirectStandardError $BACKEND_LOG -PassThru
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -7,6 +7,7 @@ BACKEND_PORT="${BACKEND_PORT:-8000}"
 FRONTEND_PORT="${FRONTEND_PORT:-5173}"
 BACKEND_HEALTH_URL="http://${BACKEND_HOST}:${BACKEND_PORT}/health"
 BACKEND_LOG="${ROOT_DIR}/.dev-backend.log"
+BACKEND_PYTHON=""
 
 BACKEND_PID=""
 
@@ -21,6 +22,31 @@ require_cmd() {
   fi
 }
 
+resolve_backend_python() {
+  local candidates=(
+    "${ROOT_DIR}/backend/venv/bin/python3"
+    "${ROOT_DIR}/backend/venv/bin/python"
+    "${ROOT_DIR}/.venv/bin/python3"
+    "${ROOT_DIR}/.venv/bin/python"
+  )
+
+  for py in "${candidates[@]}"; do
+    if [[ -x "${py}" ]] && "${py}" -c "import fastapi, uvicorn" >/dev/null 2>&1; then
+      BACKEND_PYTHON="${py}"
+      return 0
+    fi
+  done
+
+  if command -v python >/dev/null 2>&1 && python -c "import fastapi, uvicorn" >/dev/null 2>&1; then
+    BACKEND_PYTHON="python"
+    return 0
+  fi
+
+  log "Could not find a Python interpreter with fastapi and uvicorn installed."
+  log "Install backend dependencies in backend/venv or .venv, then retry."
+  exit 1
+}
+
 cleanup() {
   if [[ -n "${BACKEND_PID}" ]] && kill -0 "${BACKEND_PID}" >/dev/null 2>&1; then
     log "Stopping backend (PID ${BACKEND_PID})"
@@ -31,7 +57,6 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 require_cmd curl
-require_cmd python
 require_cmd npm
 require_cmd ss
 
@@ -46,6 +71,9 @@ if [[ ! -f "backend/.env" ]]; then
   log "backend/.env not found. Creating it from backend/.env.example."
   cp backend/.env.example backend/.env
 fi
+
+resolve_backend_python
+log "Using backend Python: ${BACKEND_PYTHON}"
 
 if command -v pg_isready >/dev/null 2>&1; then
   if pg_isready -h 127.0.0.1 -p 5432 >/dev/null 2>&1; then
@@ -67,7 +95,7 @@ else
   fi
 
   log "Starting backend on ${BACKEND_HOST}:${BACKEND_PORT}"
-  python -m uvicorn backend.main:app --host "${BACKEND_HOST}" --port "${BACKEND_PORT}" --reload >"${BACKEND_LOG}" 2>&1 &
+  "${BACKEND_PYTHON}" -m uvicorn backend.main:app --host "${BACKEND_HOST}" --port "${BACKEND_PORT}" --reload >"${BACKEND_LOG}" 2>&1 &
   BACKEND_PID="$!"
   log "Backend PID: ${BACKEND_PID} (logs: ${BACKEND_LOG})"
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+BACKEND_HEALTH_URL="http://${BACKEND_HOST}:${BACKEND_PORT}/health"
+BACKEND_LOG="${ROOT_DIR}/.dev-backend.log"
+
+BACKEND_PID=""
+
+log() {
+  printf "[%s] %s\n" "$(date +"%H:%M:%S")" "$*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "Missing required command: $1"
+    exit 1
+  fi
+}
+
+cleanup() {
+  if [[ -n "${BACKEND_PID}" ]] && kill -0 "${BACKEND_PID}" >/dev/null 2>&1; then
+    log "Stopping backend (PID ${BACKEND_PID})"
+    kill "${BACKEND_PID}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+require_cmd curl
+require_cmd python
+require_cmd npm
+require_cmd ss
+
+cd "${ROOT_DIR}"
+
+if [[ ! -d "frontend" ]]; then
+  log "frontend directory not found. Run this script from the repository root."
+  exit 1
+fi
+
+if [[ ! -f "backend/.env" ]]; then
+  log "backend/.env not found. Creating it from backend/.env.example."
+  cp backend/.env.example backend/.env
+fi
+
+if command -v pg_isready >/dev/null 2>&1; then
+  if pg_isready -h 127.0.0.1 -p 5432 >/dev/null 2>&1; then
+    log "Postgres is reachable on 127.0.0.1:5432"
+  else
+    log "Postgres is not reachable on 127.0.0.1:5432 (continuing; backend may fail if DB is required)."
+  fi
+else
+  log "pg_isready not found; skipping Postgres readiness check."
+fi
+
+if curl -fsS "${BACKEND_HEALTH_URL}" >/dev/null 2>&1; then
+  log "Backend already healthy at ${BACKEND_HEALTH_URL}"
+else
+  if ss -ltn | grep -q ":${BACKEND_PORT} "; then
+    log "Port ${BACKEND_PORT} is already in use, but ${BACKEND_HEALTH_URL} is not healthy."
+    log "Stop the process using port ${BACKEND_PORT} or set BACKEND_PORT to a different value."
+    exit 1
+  fi
+
+  log "Starting backend on ${BACKEND_HOST}:${BACKEND_PORT}"
+  python -m uvicorn backend.main:app --host "${BACKEND_HOST}" --port "${BACKEND_PORT}" --reload >"${BACKEND_LOG}" 2>&1 &
+  BACKEND_PID="$!"
+  log "Backend PID: ${BACKEND_PID} (logs: ${BACKEND_LOG})"
+
+  for i in $(seq 1 60); do
+    if curl -fsS "${BACKEND_HEALTH_URL}" >/dev/null 2>&1; then
+      log "Backend is healthy"
+      break
+    fi
+
+    if ! kill -0 "${BACKEND_PID}" >/dev/null 2>&1; then
+      log "Backend exited before becoming healthy. Last log lines:"
+      tail -n 40 "${BACKEND_LOG}" || true
+      exit 1
+    fi
+
+    sleep 1
+
+    if [[ "${i}" -eq 60 ]]; then
+      log "Timed out waiting for backend health at ${BACKEND_HEALTH_URL}"
+      tail -n 40 "${BACKEND_LOG}" || true
+      exit 1
+    fi
+  done
+fi
+
+log "Starting frontend on port ${FRONTEND_PORT}"
+cd "${ROOT_DIR}/frontend"
+exec npm run dev -- --port "${FRONTEND_PORT}" --strictPort

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -37,13 +37,27 @@ resolve_backend_python() {
     fi
   done
 
-  if command -v python >/dev/null 2>&1 && python -c "import fastapi, uvicorn" >/dev/null 2>&1; then
-    BACKEND_PYTHON="python"
-    return 0
+  for py in python3 python; do
+    if command -v "${py}" >/dev/null 2>&1 && "${py}" -c "import fastapi, uvicorn" >/dev/null 2>&1; then
+      BACKEND_PYTHON="${py}"
+      return 0
+    fi
+  done
+}
+
+port_in_use() {
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltn | grep -q ":${BACKEND_PORT} "
+    return $?
   fi
 
-  log "Could not find a Python interpreter with fastapi and uvicorn installed."
-  log "Install backend dependencies in backend/venv or .venv, then retry."
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"${BACKEND_PORT}" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+
+  log "Could not find a supported port-inspection tool (ss or lsof)."
+  log "Install one of them or set BACKEND_PORT to a known-free port."
   exit 1
 }
 
@@ -58,7 +72,6 @@ trap cleanup EXIT INT TERM
 
 require_cmd curl
 require_cmd npm
-require_cmd ss
 
 cd "${ROOT_DIR}"
 
@@ -68,6 +81,10 @@ if [[ ! -d "frontend" ]]; then
 fi
 
 if [[ ! -f "backend/.env" ]]; then
+  if [[ ! -f "backend/.env.example" ]]; then
+    log "backend/.env.example not found. Cannot bootstrap backend/.env."
+    exit 1
+  fi
   log "backend/.env not found. Creating it from backend/.env.example."
   cp backend/.env.example backend/.env
 fi
@@ -79,7 +96,8 @@ if command -v pg_isready >/dev/null 2>&1; then
   if pg_isready -h 127.0.0.1 -p 5432 >/dev/null 2>&1; then
     log "Postgres is reachable on 127.0.0.1:5432"
   else
-    log "Postgres is not reachable on 127.0.0.1:5432 (continuing; backend may fail if DB is required)."
+    log "Postgres is not reachable on 127.0.0.1:5432."
+    log "Backend health requires DB connectivity, so startup will likely fail until Postgres is available."
   fi
 else
   log "pg_isready not found; skipping Postgres readiness check."
@@ -88,7 +106,7 @@ fi
 if curl -fsS "${BACKEND_HEALTH_URL}" >/dev/null 2>&1; then
   log "Backend already healthy at ${BACKEND_HEALTH_URL}"
 else
-  if ss -ltn | grep -q ":${BACKEND_PORT} "; then
+  if port_in_use; then
     log "Port ${BACKEND_PORT} is already in use, but ${BACKEND_HEALTH_URL} is not healthy."
     log "Stop the process using port ${BACKEND_PORT} or set BACKEND_PORT to a different value."
     exit 1
@@ -123,4 +141,4 @@ fi
 
 log "Starting frontend on port ${FRONTEND_PORT}"
 cd "${ROOT_DIR}/frontend"
-exec npm run dev -- --port "${FRONTEND_PORT}" --strictPort
+npm run dev -- --port "${FRONTEND_PORT}" --strictPort

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -5,7 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
 BACKEND_PORT="${BACKEND_PORT:-8000}"
 FRONTEND_PORT="${FRONTEND_PORT:-5173}"
-BACKEND_HEALTH_URL="http://${BACKEND_HOST}:${BACKEND_PORT}/health"
+# Always probe 127.0.0.1 so the health check works even when BACKEND_HOST is 0.0.0.0
+BACKEND_HEALTH_HOST="${BACKEND_HEALTH_HOST:-127.0.0.1}"
+BACKEND_HEALTH_URL="http://${BACKEND_HEALTH_HOST}:${BACKEND_PORT}/health"
 BACKEND_LOG="${ROOT_DIR}/.dev-backend.log"
 BACKEND_PYTHON=""
 
@@ -43,6 +45,10 @@ resolve_backend_python() {
       return 0
     fi
   done
+
+  log "Could not find a Python interpreter with fastapi and uvicorn installed."
+  log "Install backend dependencies in backend/venv (or activate the venv), then retry."
+  exit 1
 }
 
 port_in_use() {
@@ -90,6 +96,11 @@ if [[ ! -f "backend/.env" ]]; then
 fi
 
 resolve_backend_python
+if [[ -z "${BACKEND_PYTHON}" ]]; then
+  log "Could not find a Python interpreter with fastapi and uvicorn installed."
+  log "Install backend dependencies in backend/venv (or activate the venv), then retry."
+  exit 1
+fi
 log "Using backend Python: ${BACKEND_PYTHON}"
 
 if command -v pg_isready >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary\n- add Linux startup entrypoint at repo root: start-dev.sh\n- add Windows startup entrypoint at repo root: start-dev.ps1\n- document a single canonical cross-platform startup flow in README\n\n## Why\nKeep local developer workflow interchangeable between Linux and Windows and prevent doc drift/deprecating startup instructions.\n\n## Behavior\nBoth scripts now:\n- validate prerequisites\n- bootstrap backend/.env from backend/.env.example when missing\n- check backend health before starting frontend\n- fail fast on backend port conflicts with actionable errors\n\n## Validation\n- bash syntax check passed for start-dev.sh\n- PowerShell parser validation could not run in this environment (pwsh not installed)\n\nCloses #394