### PR TITLE
fix: league-scoped position suppression across draft, waiver, and keepers (#340)

### DIFF
--- a/backend/routers/draft.py
+++ b/backend/routers/draft.py
@@ -19,6 +19,7 @@ from ..services.validation_service import (
     validate_draft_pick_boundary,
     validate_draft_pick_dynamic_rules,
 )
+from ..services.league_position_service import is_position_allowed_for_league
 from etl.transform.monte_carlo_simulation import (
     build_monte_carlo_inputs_from_db,
     SimulationConfig,
@@ -810,6 +811,12 @@ async def draft_player(pick: DraftPickCreate, db: Session = Depends(get_db)):
     owner = db.query(models.User).filter(models.User.id == pick.owner_id).first()
     if not owner:
         raise HTTPException(status_code=404, detail="Owner not found")
+
+    if not is_position_allowed_for_league(db, owner.league_id, player.position):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Position {player.position} is disabled for this league.",
+        )
 
     if pick.amount < 1:
         raise HTTPException(status_code=400, detail="Bid amount must be at least $1")

--- a/backend/routers/keepers.py
+++ b/backend/routers/keepers.py
@@ -15,6 +15,11 @@ from ..core.security import get_current_user, get_current_active_admin
 from ..services import keeper_service
 from ..services.player_service import normalize_display_name as _normalize_player_name
 from ..services.ledger_service import record_ledger_entry
+from ..services.league_position_service import (
+    get_active_positions_for_league,
+    is_position_allowed_for_league,
+    normalize_player_position,
+)
 from ..services.validation_service import (
     validate_keeper_settings_boundary,
     validate_keeper_settings_dynamic_rules,
@@ -283,6 +288,7 @@ def get_my_keepers(
     
     # Build dict of keeper info by player_id for eligibility checking
     keeper_by_player_id = {k.player_id: k for k in keepers}
+    active_positions = set(get_active_positions_for_league(db, current_user.league_id))
     
     # Fetch draft picks (the pool of available players to keep)
     draft_picks = (
@@ -300,6 +306,9 @@ def get_my_keepers(
     for pick in draft_picks:
         if not pick.player:
             continue
+        player_position = normalize_player_position(pick.player.position)
+        if player_position not in active_positions:
+            continue
         
         is_selected = pick.player_id in selected_player_ids
         keeper_info = keeper_by_player_id.get(pick.player_id)
@@ -316,7 +325,7 @@ def get_my_keepers(
         available_players.append(AvailablePlayerSchema(
             player_id=pick.player_id,
             name=_normalize_player_name(pick.player.name),
-            position=pick.player.position if pick.player.position != "TD" else "DEF",
+            position=player_position,
             nfl_team=pick.player.nfl_team,
             draft_price=int(pick.amount),
             is_selected=is_selected,
@@ -374,6 +383,14 @@ def save_my_keepers(
     for p in request.players:
         if p.player_id in override_player_ids:
             continue
+        player = db.query(models.Player).filter(models.Player.id == p.player_id).first()
+        if not player:
+            raise HTTPException(status_code=404, detail="Keeper player not found.")
+        if not is_position_allowed_for_league(db, current_user.league_id, player.position):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Position {player.position} is disabled for this league.",
+            )
         k = models.Keeper(
             league_id=current_user.league_id,
             owner_id=current_user.id,

--- a/backend/routers/keepers.py
+++ b/backend/routers/keepers.py
@@ -17,7 +17,6 @@ from ..services.player_service import normalize_display_name as _normalize_playe
 from ..services.ledger_service import record_ledger_entry
 from ..services.league_position_service import (
     get_active_positions_for_league,
-    is_position_allowed_for_league,
     normalize_player_position,
 )
 from ..services.validation_service import (
@@ -380,13 +379,27 @@ def save_my_keepers(
         models.Keeper.season == season,
         models.Keeper.status == "pending",
     ).delete(synchronize_session="fetch")
+
+    active_positions = set(get_active_positions_for_league(db, current_user.league_id))
+    player_ids = [
+        p.player_id
+        for p in request.players
+        if p.player_id not in override_player_ids
+    ]
+    players_by_id = {
+        player.id: player
+        for player in db.query(models.Player)
+        .filter(models.Player.id.in_(player_ids))
+        .all()
+    }
+
     for p in request.players:
         if p.player_id in override_player_ids:
             continue
-        player = db.query(models.Player).filter(models.Player.id == p.player_id).first()
+        player = players_by_id.get(p.player_id)
         if not player:
             raise HTTPException(status_code=404, detail="Keeper player not found.")
-        if not is_position_allowed_for_league(db, current_user.league_id, player.position):
+        if normalize_player_position(player.position) not in active_positions:
             raise HTTPException(
                 status_code=400,
                 detail=f"Position {player.position} is disabled for this league.",

--- a/backend/routers/players.py
+++ b/backend/routers/players.py
@@ -228,7 +228,11 @@ def get_all_players(
     league_id: Optional[int] = Query(None),
     db: Session = Depends(get_db),
 ):
-    """Return all relevant fantasy players (QB, RB, WR, TE, K, DEF) from active NFL rosters."""
+    """Return relevant fantasy players from active NFL rosters.
+
+    When league_id is provided, results are filtered to that league's
+    active fantasy positions.
+    """
     deduped = player_service.get_all_relevant_players(db, league_id)
     return [
         {

--- a/backend/routers/players.py
+++ b/backend/routers/players.py
@@ -73,10 +73,11 @@ def _build_team_logo_url(team_abbr: Optional[str]) -> Optional[str]:
 def search_players(
     q: str = Query(..., min_length=2), 
     pos: str = Query("ALL"), 
+    league_id: Optional[int] = Query(None),
     db: Session = Depends(get_db)
 ):
     # 2.2.1 CALL the service for searching
-    results = player_service.search_all_players(db, q, pos)
+    results = player_service.search_all_players(db, q, pos, league_id)
     return [
         {
             "id": p.id,
@@ -223,9 +224,12 @@ def get_player_season_details(
 
 # --- NEW: GET /players/ ---
 @router.get("/", response_model=list[PlayerSearchResult])
-def get_all_players(db: Session = Depends(get_db)):
+def get_all_players(
+    league_id: Optional[int] = Query(None),
+    db: Session = Depends(get_db),
+):
     """Return all relevant fantasy players (QB, RB, WR, TE, K, DEF) from active NFL rosters."""
-    deduped = player_service.get_all_relevant_players(db)
+    deduped = player_service.get_all_relevant_players(db, league_id)
     return [
         {
             "id": p.id,

--- a/backend/services/league_position_service.py
+++ b/backend/services/league_position_service.py
@@ -1,0 +1,52 @@
+from sqlalchemy.orm import Session
+
+from .. import models
+
+
+ACTIVE_PLAYER_POSITIONS = ("QB", "RB", "WR", "TE", "K", "DEF")
+
+
+def normalize_player_position(position: str | None) -> str:
+    normalized = str(position or "").strip().upper()
+    if normalized == "TD":
+        return "DEF"
+    return normalized
+
+
+def get_active_positions_for_league(db: Session, league_id: int | None) -> list[str]:
+    if not league_id:
+        return list(ACTIVE_PLAYER_POSITIONS)
+
+    settings = (
+        db.query(models.LeagueSettings)
+        .filter(models.LeagueSettings.league_id == league_id)
+        .first()
+    )
+    if not settings or not isinstance(settings.starting_slots, dict):
+        return list(ACTIVE_PLAYER_POSITIONS)
+
+    slots = settings.starting_slots or {}
+    active_positions: list[str] = []
+    for position in ACTIVE_PLAYER_POSITIONS:
+        max_key = f"MAX_{position}"
+        fallback = 1 if position == "DEF" else 0
+        raw_value = slots.get(max_key, slots.get(position, fallback))
+        try:
+            enabled = int(raw_value) > 0
+        except (TypeError, ValueError):
+            enabled = position == "DEF"
+        if enabled:
+            active_positions.append(position)
+
+    return active_positions or list(ACTIVE_PLAYER_POSITIONS)
+
+
+def is_position_allowed_for_league(
+    db: Session,
+    league_id: int | None,
+    player_position: str | None,
+) -> bool:
+    normalized_position = normalize_player_position(player_position)
+    if not normalized_position:
+        return False
+    return normalized_position in set(get_active_positions_for_league(db, league_id))

--- a/backend/services/league_position_service.py
+++ b/backend/services/league_position_service.py
@@ -25,7 +25,17 @@ def get_active_positions_for_league(db: Session, league_id: int | None) -> list[
     if not settings or not isinstance(settings.starting_slots, dict):
         return list(ACTIVE_PLAYER_POSITIONS)
 
-    slots = settings.starting_slots or {}
+    slots = settings.starting_slots
+    if not slots:
+        return list(ACTIVE_PLAYER_POSITIONS)
+
+    has_position_config = any(
+        f"MAX_{position}" in slots or position in slots
+        for position in ACTIVE_PLAYER_POSITIONS
+    )
+    if not has_position_config:
+        return list(ACTIVE_PLAYER_POSITIONS)
+
     active_positions: list[str] = []
     for position in ACTIVE_PLAYER_POSITIONS:
         max_key = f"MAX_{position}"

--- a/backend/services/player_service.py
+++ b/backend/services/player_service.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from sqlalchemy import and_, exists, func, or_
 from sqlalchemy.orm import Session
 from .. import models
+from .league_position_service import get_active_positions_for_league
 
 # Only relevant fantasy positions from active NFL rosters
 ALLOWED_POSITIONS = {"QB", "RB", "WR", "TE", "K", "DEF"}
@@ -262,11 +263,12 @@ def _active_player_or_unsynced_filter(db: Session):
     return or_(has_active_recent_season, has_unsynced_but_plausible_team)
 
 
-def get_all_relevant_players(db: Session) -> list[models.Player]:
+def get_all_relevant_players(db: Session, league_id: int | None = None) -> list[models.Player]:
+    active_positions = get_active_positions_for_league(db, league_id)
     rows = (
         db.query(models.Player)
         .filter(
-            models.Player.position.in_(ALLOWED_POSITIONS),
+            models.Player.position.in_(active_positions),
             _active_player_or_unsynced_filter(db),
         )
         .order_by(models.Player.name, models.Player.id.desc())
@@ -358,16 +360,22 @@ def get_player_quality_report(db: Session) -> dict[str, object]:
     }
 
 # 1.1.1 SERVICE: Search ALL players with position filtering
-def search_all_players(db: Session, query_str: str, pos: str = "ALL"):
+def search_all_players(
+    db: Session,
+    query_str: str,
+    pos: str = "ALL",
+    league_id: int | None = None,
+):
     search_term = f"%{query_str.strip()}%"
+    active_positions = get_active_positions_for_league(db, league_id)
     # Always filter to relevant positions
     query = db.query(models.Player).filter(
         models.Player.name.ilike(search_term),
-        models.Player.position.in_(ALLOWED_POSITIONS),
+        models.Player.position.in_(active_positions),
         _active_player_or_unsynced_filter(db),
     )
     
-    if pos != "ALL":
+    if pos != "ALL" and pos in active_positions:
         query = query.filter(models.Player.position == pos)
     
     rows = query.limit(60).all()
@@ -375,6 +383,7 @@ def search_all_players(db: Session, query_str: str, pos: str = "ALL"):
 
 # 1.1.2 SERVICE: Find Available Free Agents in a specific league
 def get_league_free_agents(db: Session, league_id: int):
+    active_positions = get_active_positions_for_league(db, league_id)
     # Subquery for IDs of all players owned in THIS league
     owned_ids_query = db.query(models.DraftPick.player_id).filter(
         models.DraftPick.league_id == league_id
@@ -383,7 +392,7 @@ def get_league_free_agents(db: Session, league_id: int):
     # Return only relevant position players NOT owned in this league
     rows = db.query(models.Player).filter(
         ~models.Player.id.in_(owned_ids_query),
-        models.Player.position.in_(ALLOWED_POSITIONS)
+        models.Player.position.in_(active_positions)
     ).limit(250).all()
     return dedupe_players(rows)[:50]
 

--- a/backend/services/player_service.py
+++ b/backend/services/player_service.py
@@ -400,6 +400,7 @@ def get_league_free_agents(db: Session, league_id: int):
 def get_top_free_agents(db: Session, league_id: int, limit: int = 10):
     """Return top available free agents ranked by projection, ADP, and waiver momentum."""
     safe_limit = max(1, min(int(limit), 25))
+    active_positions = get_active_positions_for_league(db, league_id)
     owned_ids_query = db.query(models.DraftPick.player_id).filter(
         models.DraftPick.league_id == league_id
     )
@@ -407,7 +408,7 @@ def get_top_free_agents(db: Session, league_id: int, limit: int = 10):
         db.query(models.Player)
         .filter(
             ~models.Player.id.in_(owned_ids_query),
-            models.Player.position.in_(ALLOWED_POSITIONS),
+            models.Player.position.in_(active_positions),
         )
         .order_by(
             models.Player.projected_points.desc(),

--- a/backend/services/waiver_service.py
+++ b/backend/services/waiver_service.py
@@ -10,6 +10,7 @@ from .validation_service import (
     validate_waiver_claim_dynamic_rules,
 )
 from .commissioner_deadline_service import enforce_commissioner_deadline
+from .league_position_service import is_position_allowed_for_league
 
 
 def _validate_commissioner_waiver_rules(db: Session, user: models.User) -> int:
@@ -110,6 +111,15 @@ def process_claim(db: Session, user: models.User, player_id: int, bid: int, drop
     ).first()
     if existing:
         raise HTTPException(status_code=400, detail="Player already owned!")
+
+    player = db.query(models.Player).filter(models.Player.id == player_id).first()
+    if not player:
+        raise HTTPException(status_code=404, detail="Player not found.")
+    if not is_position_allowed_for_league(db, user.league_id, player.position):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Position {player.position} is disabled for this league.",
+        )
 
     # 2.1 CONDITIONAL DROP: If drop_id is provided, remove them first
     if drop_id:

--- a/backend/tests/test_draft_validation.py
+++ b/backend/tests/test_draft_validation.py
@@ -46,3 +46,54 @@ async def test_draft_player_rejects_invalid_session_id(db_session):
         await draft_player(pick, db=db_session)
 
     assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_draft_player_rejects_suppressed_position(db_session):
+    league = models.League(name="L-DRAFT-SUPPRESSION", draft_status="PRE_DRAFT")
+    owner = models.User(username="owner-suppressed", hashed_password="pw", league_id=1)
+    player = models.Player(name="Suppressed Kicker", position="K", nfl_team="ABC")
+    db_session.add_all([league, owner, player])
+    db_session.commit()
+    db_session.refresh(league)
+    owner.league_id = league.id
+    db_session.add(
+        models.LeagueSettings(
+            league_id=league.id,
+            draft_year=2026,
+            roster_size=14,
+            starting_slots={
+                "QB": 1,
+                "RB": 2,
+                "WR": 2,
+                "TE": 1,
+                "K": 0,
+                "DEF": 1,
+                "FLEX": 1,
+                "MAX_QB": 1,
+                "MAX_RB": 3,
+                "MAX_WR": 3,
+                "MAX_TE": 2,
+                "MAX_K": 0,
+                "MAX_DEF": 1,
+                "MAX_FLEX": 1,
+            },
+        )
+    )
+    db_session.commit()
+    db_session.refresh(owner)
+    db_session.refresh(player)
+
+    pick = DraftPickCreate(
+        owner_id=owner.id,
+        player_id=player.id,
+        amount=5,
+        session_id=f"LEAGUE_{league.id}_YEAR_2026",
+        year=2026,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await draft_player(pick, db=db_session)
+
+    assert exc.value.status_code == 400
+    assert "disabled for this league" in exc.value.detail

--- a/backend/tests/test_keeper_router.py
+++ b/backend/tests/test_keeper_router.py
@@ -253,6 +253,72 @@ def test_keeper_settings_propagate_to_owner_page_and_lock_enforcement():
         lock_my_keepers(db=db_session, current_user=db_session.get(models.User, owner.id))
 
 
+def test_keeper_page_filters_suppressed_positions_and_rejects_submission():
+    db_session = setup_db()
+    league = make_league(db_session)
+    owner = make_user(db_session, league, "owner-suppressed", budget=200)
+    current = CU(owner)
+
+    db_session.query(models.LeagueSettings).filter(models.LeagueSettings.league_id == league.id).update(
+        {
+            "starting_slots": {
+                "QB": 1,
+                "RB": 2,
+                "WR": 2,
+                "TE": 1,
+                "K": 0,
+                "DEF": 1,
+                "FLEX": 1,
+                "MAX_QB": 1,
+                "MAX_RB": 3,
+                "MAX_WR": 3,
+                "MAX_TE": 2,
+                "MAX_K": 0,
+                "MAX_DEF": 1,
+                "MAX_FLEX": 1,
+            }
+        },
+        synchronize_session=False,
+    )
+
+    kicker = models.Player(name="Suppressed Keeper", position="K", nfl_team="ABC")
+    runner = models.Player(name="Eligible Keeper", position="RB", nfl_team="ABC")
+    db_session.add_all([kicker, runner])
+    db_session.commit()
+    db_session.refresh(kicker)
+    db_session.refresh(runner)
+
+    db_session.add_all(
+        [
+            models.DraftPick(owner_id=owner.id, player_id=kicker.id, league_id=league.id, amount=5),
+            models.DraftPick(owner_id=owner.id, player_id=runner.id, league_id=league.id, amount=6),
+        ]
+    )
+    db_session.commit()
+
+    owner_view = get_my_keepers(db=db_session, current_user=current)
+    available_positions = {player.position for player in owner_view.available_players}
+    assert "K" not in available_positions
+    assert "RB" in available_positions
+
+    req = type("R", (), {})()
+    req.players = [
+        KeeperSelectionSchema(
+            player_id=kicker.id,
+            keep_cost=5,
+            years_kept_count=0,
+            status="pending",
+            approved_by_commish=False,
+        )
+    ]
+
+    with pytest.raises(HTTPException) as exc:
+        save_my_keepers(request=req, db=db_session, current_user=current)
+
+    assert exc.value.status_code == 400
+    assert "disabled for this league" in exc.value.detail
+
+
 def test_update_keeper_settings_rejects_invalid_values():
     db_session = setup_db()
     league = make_league(db_session)

--- a/backend/tests/test_waiver_service.py
+++ b/backend/tests/test_waiver_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import sessionmaker
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import models
+from backend.services.player_service import get_league_free_agents, search_all_players
 from backend.services.waiver_service import process_claim
 
 
@@ -120,3 +121,79 @@ def test_process_claim_rejects_after_commissioner_waiver_deadline(db_session):
 
     assert exc.value.status_code == 400
     assert "Waiver claims are closed by commissioner rule" in str(exc.value.detail)
+
+
+def test_process_claim_rejects_suppressed_position(db_session):
+    league = make_league(db_session)
+    user = make_user(db_session, league, "waiver-owner-suppressed")
+    target = models.Player(name="Suppressed Kicker", position="K", nfl_team="ABC")
+    db_session.add(target)
+    db_session.add(
+        models.LeagueSettings(
+            league_id=league.id,
+            starting_slots={
+                "QB": 1,
+                "RB": 2,
+                "WR": 2,
+                "TE": 1,
+                "K": 0,
+                "DEF": 1,
+                "FLEX": 1,
+                "MAX_QB": 1,
+                "MAX_RB": 3,
+                "MAX_WR": 3,
+                "MAX_TE": 2,
+                "MAX_K": 0,
+                "MAX_DEF": 1,
+                "MAX_FLEX": 1,
+            },
+        )
+    )
+    db_session.commit()
+    db_session.refresh(target)
+
+    with pytest.raises(HTTPException) as exc:
+        process_claim(db_session, user=user, player_id=target.id, bid=0)
+
+    assert exc.value.status_code == 400
+    assert "disabled for this league" in exc.value.detail
+
+
+def test_player_pools_respect_league_scoped_position_suppression(db_session):
+    league = make_league(db_session)
+    user = make_user(db_session, league, "waiver-owner-pools")
+    db_session.add(
+        models.LeagueSettings(
+            league_id=league.id,
+            starting_slots={
+                "QB": 1,
+                "RB": 2,
+                "WR": 2,
+                "TE": 1,
+                "K": 0,
+                "DEF": 1,
+                "FLEX": 1,
+                "MAX_QB": 1,
+                "MAX_RB": 3,
+                "MAX_WR": 3,
+                "MAX_TE": 2,
+                "MAX_K": 0,
+                "MAX_DEF": 1,
+                "MAX_FLEX": 1,
+            },
+        )
+    )
+    kicker = models.Player(name="Suppressed Pool Kicker", position="K", nfl_team="ABC")
+    runner = models.Player(name="Eligible Pool Runner", position="RB", nfl_team="ABC")
+    db_session.add_all([kicker, runner])
+    db_session.commit()
+
+    free_agents = get_league_free_agents(db_session, league.id)
+    free_agent_positions = {player.position for player in free_agents}
+    assert "K" not in free_agent_positions
+    assert "RB" in free_agent_positions
+
+    search_results = search_all_players(db_session, "Pool", "ALL", league.id)
+    search_positions = {player.position for player in search_results}
+    assert "K" not in search_positions
+    assert "RB" in search_positions

--- a/frontend/cypress/e2e/draftboard.smoke.spec.js
+++ b/frontend/cypress/e2e/draftboard.smoke.spec.js
@@ -23,7 +23,7 @@ describe('DraftBoard smoke', () => {
       ],
     }).as('owners');
 
-    cy.intercept('GET', '**/players/', {
+    cy.intercept('GET', /\/players\//, {
       statusCode: 200,
       body: [
         {

--- a/frontend/src/components/draft/AuctionBlock.jsx
+++ b/frontend/src/components/draft/AuctionBlock.jsx
@@ -16,6 +16,7 @@ export default function AuctionBlock({
   suggestions,
   showSuggestions,
   selectSuggestion,
+  positions = POSITIONS,
   posFilter,
   setPosFilter,
   winnerId,
@@ -76,7 +77,7 @@ export default function AuctionBlock({
       <div className="flex flex-col gap-2 text-[12px] text-slate-300">
         {/* position filter row */}
         <div className="flex flex-wrap gap-1">
-          {['ALL', ...POSITIONS].map((pos) => (
+          {['ALL', ...positions].map((pos) => (
             <button
               key={pos}
               onClick={() => setPosFilter(pos)}
@@ -250,7 +251,7 @@ export default function AuctionBlock({
             <span className="font-bold text-white">{nominatorName}</span>
           </div>
           <div className="flex flex-wrap gap-1 mb-2">
-            {['ALL', ...POSITIONS].map((pos) => (
+            {['ALL', ...positions].map((pos) => (
               <button
                 key={pos}
                 onClick={() => setPosFilter(pos)}

--- a/frontend/src/components/waivers/WaiverPositionTabs.jsx
+++ b/frontend/src/components/waivers/WaiverPositionTabs.jsx
@@ -5,8 +5,8 @@ import { buttonPrimary, buttonSecondary } from '@utils/uiStandards';
 
 /* ignore-breakpoints */
 
-export default function WaiverPositionTabs({ activeTab, setActiveTab }) {
-  const tabs = ['ALL', ...POSITIONS];
+export default function WaiverPositionTabs({ activeTab, setActiveTab, positions = POSITIONS }) {
+  const tabs = ['ALL', ...positions];
 
   return (
     <div className="flex gap-2 overflow-x-auto pb-4 no-scrollbar">

--- a/frontend/src/pages/DraftBoard.jsx
+++ b/frontend/src/pages/DraftBoard.jsx
@@ -28,7 +28,20 @@ import {
   tableCellNumeric,
 } from '@utils/uiStandards';
 
+const PLAYER_POSITIONS = ['QB', 'RB', 'WR', 'TE', 'K', 'DEF'];
+
 const normalizeTeamCode = (value) => String(value || '').trim().toUpperCase();
+
+const getLeagueActivePositions = (settings) => {
+  const slots = settings?.starting_slots || {};
+  return PLAYER_POSITIONS.filter((position) => {
+    const rawValue =
+      slots[`MAX_${position}`] ??
+      slots[position] ??
+      (position === 'DEF' ? 1 : 0);
+    return Number(rawValue) > 0;
+  });
+};
 
 const isActiveDraftPlayer = (player) => {
   const team = normalizeTeamCode(player?.nfl_team);
@@ -59,6 +72,7 @@ export default function DraftBoard({ token, activeOwnerId, activeLeagueId }) {
   const [suggestions, setSuggestions] = useState([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [posFilter, setPosFilter] = useState('ALL');
+  const [activePositions, setActivePositions] = useState(PLAYER_POSITIONS);
   const [showPlayerPerformance, setShowPlayerPerformance] = useState(false);
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const [playerPerformance, setPlayerPerformance] = useState(null);
@@ -187,7 +201,7 @@ export default function DraftBoard({ token, activeOwnerId, activeLeagueId }) {
     if (val.length > 1) {
       try {
         const res = await apiClient.get(
-          `/players/search?q=${val}&pos=${posFilter}`
+          `/players/search?q=${val}&pos=${posFilter}&league_id=${activeLeagueId}`
         );
         const draftedIds = new Set(history.map((h) => h.player_id));
         const filtered = res.data
@@ -219,7 +233,7 @@ export default function DraftBoard({ token, activeOwnerId, activeLeagueId }) {
         .get(`/leagues/owners?league_id=${leagueIdInt}`)
         .then((res) => setOwners(res.data))
         .catch(() => setOwners([]));
-      apiClient.get('/players/').then((res) => setPlayers(res.data));
+      apiClient.get(`/players/?league_id=${leagueIdInt}`).then((res) => setPlayers(res.data));
       fetchHistory();
       // Fetch league name and user info
       apiClient
@@ -239,6 +253,10 @@ export default function DraftBoard({ token, activeOwnerId, activeLeagueId }) {
       apiClient
         .get(`/leagues/${activeLeagueId}/settings`)
         .then((res) => {
+          const nextActivePositions = getLeagueActivePositions(res.data);
+          setActivePositions(
+            nextActivePositions.length > 0 ? nextActivePositions : PLAYER_POSITIONS
+          );
           if (res.data?.draft_year) {
             setDraftYear(res.data.draft_year);
           }
@@ -257,6 +275,13 @@ export default function DraftBoard({ token, activeOwnerId, activeLeagueId }) {
     setIsPaused((p) => !p);
     // TODO: notify backend or disable interactions
   }, []);
+
+  useEffect(() => {
+    if (posFilter === 'ALL') return;
+    if (!activePositions.includes(posFilter)) {
+      setPosFilter('ALL');
+    }
+  }, [activePositions, posFilter]);
 
   useEffect(() => {
     if (!activeLeagueId || !draftYear) return;
@@ -507,6 +532,7 @@ export default function DraftBoard({ token, activeOwnerId, activeLeagueId }) {
             suggestions={suggestions}
             showSuggestions={showSuggestions}
             selectSuggestion={selectSuggestion}
+            positions={activePositions}
             posFilter={posFilter}
             setPosFilter={setPosFilter}
             winnerId={winnerId}

--- a/frontend/src/pages/DraftBoard.jsx
+++ b/frontend/src/pages/DraftBoard.jsx
@@ -33,14 +33,27 @@ const PLAYER_POSITIONS = ['QB', 'RB', 'WR', 'TE', 'K', 'DEF'];
 const normalizeTeamCode = (value) => String(value || '').trim().toUpperCase();
 
 const getLeagueActivePositions = (settings) => {
-  const slots = settings?.starting_slots || {};
-  return PLAYER_POSITIONS.filter((position) => {
+  const slots = settings?.starting_slots;
+  if (!slots || Object.keys(slots).length === 0) {
+    return PLAYER_POSITIONS;
+  }
+
+  const hasPositionConfig = PLAYER_POSITIONS.some(
+    (position) => slots[`MAX_${position}`] != null || slots[position] != null
+  );
+  if (!hasPositionConfig) {
+    return PLAYER_POSITIONS;
+  }
+
+  const activePositions = PLAYER_POSITIONS.filter((position) => {
     const rawValue =
       slots[`MAX_${position}`] ??
       slots[position] ??
       (position === 'DEF' ? 1 : 0);
     return Number(rawValue) > 0;
   });
+
+  return activePositions.length > 0 ? activePositions : PLAYER_POSITIONS;
 };
 
 const isActiveDraftPlayer = (player) => {

--- a/frontend/src/pages/WaiverWire.jsx
+++ b/frontend/src/pages/WaiverWire.jsx
@@ -19,14 +19,27 @@ import {
 const PLAYER_POSITIONS = ['QB', 'RB', 'WR', 'TE', 'K', 'DEF'];
 
 const getLeagueActivePositions = (settings) => {
-  const slots = settings?.starting_slots || {};
-  return PLAYER_POSITIONS.filter((position) => {
+  const slots = settings?.starting_slots;
+  if (!slots || Object.keys(slots).length === 0) {
+    return PLAYER_POSITIONS;
+  }
+
+  const hasPositionConfig = PLAYER_POSITIONS.some(
+    (position) => slots[`MAX_${position}`] != null || slots[position] != null
+  );
+  if (!hasPositionConfig) {
+    return PLAYER_POSITIONS;
+  }
+
+  const activePositions = PLAYER_POSITIONS.filter((position) => {
     const rawValue =
       slots[`MAX_${position}`] ??
       slots[position] ??
       (position === 'DEF' ? 1 : 0);
     return Number(rawValue) > 0;
   });
+
+  return activePositions.length > 0 ? activePositions : PLAYER_POSITIONS;
 };
 
 export default function WaiverWire({ ownerId, username, leagueName }) {

--- a/frontend/src/pages/WaiverWire.jsx
+++ b/frontend/src/pages/WaiverWire.jsx
@@ -16,6 +16,19 @@ import {
   layerModal,
 } from '../utils/uiStandards';
 
+const PLAYER_POSITIONS = ['QB', 'RB', 'WR', 'TE', 'K', 'DEF'];
+
+const getLeagueActivePositions = (settings) => {
+  const slots = settings?.starting_slots || {};
+  return PLAYER_POSITIONS.filter((position) => {
+    const rawValue =
+      slots[`MAX_${position}`] ??
+      slots[position] ??
+      (position === 'DEF' ? 1 : 0);
+    return Number(rawValue) > 0;
+  });
+};
+
 export default function WaiverWire({ ownerId, username, leagueName }) {
   const navigate = useNavigate();
   // --- 1.1 STATE MANAGEMENT ---
@@ -24,6 +37,7 @@ export default function WaiverWire({ ownerId, username, leagueName }) {
   const [loading, setLoading] = useState(true);
   const [processingId, setProcessingId] = useState(null);
   const [activeTab, setActiveTab] = useState('ALL');
+  const [activePositions, setActivePositions] = useState(PLAYER_POSITIONS);
   const [searchQuery, setSearchQuery] = useState('');
   const [waiverDeadline, setWaiverDeadline] = useState(null); // New state for waiver deadline
   const [draftStatus, setDraftStatus] = useState('PRE_DRAFT');
@@ -76,11 +90,16 @@ export default function WaiverWire({ ownerId, username, leagueName }) {
           const res = await apiClient.get(`/leagues/${leagueName}/settings`);
           setWaiverDeadline(res.data.waiver_deadline);
           setRosterSizeLimit(res.data.roster_size || 14);
+          const nextActivePositions = getLeagueActivePositions(res.data);
+          setActivePositions(
+            nextActivePositions.length > 0 ? nextActivePositions : PLAYER_POSITIONS
+          );
         }
       } catch {
         setWaiverDeadline(null);
         setDraftStatus('PRE_DRAFT');
         setRosterSizeLimit(14);
+        setActivePositions(PLAYER_POSITIONS);
       }
     };
     fetchWaiverDeadline();
@@ -90,6 +109,13 @@ export default function WaiverWire({ ownerId, username, leagueName }) {
     }, 10000);
     return () => clearTimeout(timeout);
   }, [ownerId, fetchWaivers, leagueName]);
+
+  useEffect(() => {
+    if (activeTab === 'ALL') return;
+    if (!activePositions.includes(activeTab)) {
+      setActiveTab('ALL');
+    }
+  }, [activePositions, activeTab]);
 
   // --- 2.1 ACTION: CLAIM PLAYER ---
 
@@ -283,6 +309,7 @@ export default function WaiverWire({ ownerId, username, leagueName }) {
           <WaiverPositionTabs
             activeTab={activeTab}
             setActiveTab={setActiveTab}
+            positions={activePositions}
           />
 
           <div className="mt-8">


### PR DESCRIPTION
## Summary

Fixes #340 — positions disabled in a league's `starting_slots` settings were not being filtered out of player pools or blocked at submission time across any of the three main action paths.

This is also the **first completed example** of Epic: Layer B — League Settings Propagation Service (#399).

---

## What changed

### New service: `league_position_service.py`
Single source of truth for which positions are active in a given league. Reads `LeagueSettings.starting_slots`, checks `MAX_{POS}` keys, falls back to the full position set when no settings exist. Replaces all scattered `ALLOWED_POSITIONS` hardcoded checks.

### Backend enforcement
| Path | Change |
|---|---|
| `routers/draft.py` | Rejects draft picks for positions disabled in the owner's league (HTTP 400) |
| `services/waiver_service.py` | Rejects waiver claims for disabled positions (HTTP 400) |
| `routers/keepers.py` | Filters available players list; rejects keeper submissions for disabled positions. Also fixes `TD → DEF` normalisation bug on keeper display. |

### Player pools
`player_service.py` — all four query functions (`get_all_relevant_players`, `search_all_players`, `get_league_free_agents`, `get_top_free_agents`) now use league-scoped active positions when `league_id` is supplied.

`routers/players.py` — `/players/` and `/players/search` accept an optional `league_id` query param and forward it to the service.

### Frontend filters
- `DraftBoard.jsx` — reads `starting_slots` from league settings on load, derives active positions, passes to `AuctionBlock`, resets `posFilter` if it becomes invalid
- `WaiverWire.jsx` — same pattern, passes active positions to `WaiverPositionTabs`, resets `activeTab` on settings change
- `AuctionBlock.jsx` / `WaiverPositionTabs.jsx` — accept a `positions` prop (default to full `POSITIONS` constant for backwards compatibility)

### Tests
4 new SQLite-backed unit tests covering:
- Draft rejects suppressed position
- Waiver rejects suppressed position
- Player pools exclude suppressed positions (`get_league_free_agents` + `search_all_players`)
- Keeper page filters suppressed positions and rejects submission

All 15 targeted tests pass. No lint/type errors.

---

## Notes
- Pre-existing PostgreSQL schema mismatch (`column "current_season" does not exist`) causes unrelated failures in `test_players_router.py` integration tests — not caused by these changes.
- This PR also contributes to Epic #399 (Layer B) and is referenced from that issue as the reference implementation.
