### PR TITLE
fix: enable manual division assignment UI and backend support (#423)

### DIFF
--- a/backend/routers/divisions.py
+++ b/backend/routers/divisions.py
@@ -317,6 +317,45 @@ def preview_assignment(
         if not payload.manual_assignments:
             raise HTTPException(status_code=400, detail="manual_assignments is required for manual previews")
 
+        valid_team_ids = {item.team_id for item in strengths}
+        all_league_team_ids = {item.team_id for item in team_inputs}
+        valid_division_indices = set(range(division_count))
+        errors: list[str] = []
+
+        # Validate division indices are within range
+        for key in payload.manual_assignments:
+            if int(key) not in valid_division_indices:
+                errors.append(
+                    f"Division index {key} is out of range (0..{division_count - 1})."
+                )
+
+        # Collect all assigned team ids to check for duplicates and completeness
+        all_assigned: list[int] = []
+        for key, team_ids in payload.manual_assignments.items():
+            if int(key) not in valid_division_indices:
+                continue
+            for team_id in team_ids:
+                if team_id not in valid_team_ids:
+                    errors.append(f"Team id {team_id} does not belong to this league.")
+                all_assigned.append(team_id)
+
+        # Check for duplicates
+        seen: set[int] = set()
+        for team_id in all_assigned:
+            if team_id in seen:
+                errors.append(f"Team id {team_id} appears in more than one division.")
+            seen.add(team_id)
+
+        # Check all league teams are assigned
+        missing = all_league_team_ids - seen
+        if missing:
+            errors.append(
+                f"The following team ids are not assigned to any division: {sorted(missing)}."
+            )
+
+        if errors:
+            raise HTTPException(status_code=422, detail=errors)
+
         by_team = {item.team_id: item for item in strengths}
         assignment_rows: dict[int, list[Any]] = {}
         for key, team_ids in payload.manual_assignments.items():

--- a/backend/routers/divisions.py
+++ b/backend/routers/divisions.py
@@ -52,6 +52,7 @@ class DivisionFinalizeRequest(BaseModel):
     season: int
     assignment_method: str
     random_seed: str | None = None
+    manual_assignments: dict[int, list[int]] | None = None
 
 
 class DivisionReportNameRequest(BaseModel):
@@ -407,6 +408,7 @@ def finalize_assignment(
             season=payload.season,
             assignment_method=payload.assignment_method,
             random_seed=payload.random_seed,
+            manual_assignments=payload.manual_assignments,
         ),
         db=db,
         current_user=current_user,

--- a/backend/tests/test_divisions_router.py
+++ b/backend/tests/test_divisions_router.py
@@ -295,3 +295,197 @@ def test_report_name_skips_name_validation_when_no_season(client, api_db):
         json={"division_name": "Whatever"},
     )
     assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Manual assignment path tests
+# ---------------------------------------------------------------------------
+
+def _setup_manual_league(db, client, app, commissioner, league, users, team_count=6):
+    """Configure divisions for league and return a valid manual_assignments dict."""
+    assert team_count % 2 == 0, "Need even team count for 2 divisions"
+    cfg = client.put(
+        f"/leagues/{league.id}/divisions/config",
+        json={
+            "season": 2026,
+            "enabled": True,
+            "division_count": 2,
+            "assignment_method": "manual",
+            "names": [
+                {"name": "North", "order_index": 0},
+                {"name": "South", "order_index": 1},
+            ],
+        },
+    )
+    assert cfg.status_code == 200
+    # Split users evenly between two divisions
+    half = team_count // 2
+    return {
+        0: [u.id for u in users[:half]],
+        1: [u.id for u in users[half:]],
+    }
+
+
+def test_manual_assignment_preview_success(client, api_db):
+    """Valid manual_assignments produces a preview with all teams assigned."""
+    db, _ = api_db
+    league, commissioner, users = _seed_league(db, team_count=6)
+    app.dependency_overrides[divisions_router.get_current_user] = lambda: commissioner
+
+    manual = _setup_manual_league(db, client, app, commissioner, league, users, team_count=6)
+
+    res = client.post(
+        f"/leagues/{league.id}/divisions/assignment-preview",
+        json={
+            "season": 2026,
+            "assignment_method": "manual",
+            "manual_assignments": manual,
+        },
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["assignment_method"] == "manual"
+    assert len(data["assignments"]) == 2
+    all_team_ids = [tid for row in data["assignments"] for tid in row["team_ids"]]
+    assert sorted(all_team_ids) == sorted(u.id for u in users)
+
+
+def test_manual_assignment_finalize_assigns_all_teams(client, api_db):
+    """Finalize with a valid manual map sets division_id on all users."""
+    db, _ = api_db
+    league, commissioner, users = _seed_league(db, team_count=6)
+    app.dependency_overrides[divisions_router.get_current_user] = lambda: commissioner
+
+    manual = _setup_manual_league(db, client, app, commissioner, league, users, team_count=6)
+
+    res = client.post(
+        f"/leagues/{league.id}/divisions/finalize",
+        json={
+            "season": 2026,
+            "assignment_method": "manual",
+            "manual_assignments": manual,
+        },
+    )
+    assert res.status_code == 200
+
+    for user in users:
+        db.refresh(user)
+        assert user.division_id is not None, f"User {user.id} has no division_id after finalize"
+
+
+def test_manual_assignment_preview_rejects_missing_teams(client, api_db):
+    """manual_assignments that omits some league teams returns 422."""
+    db, _ = api_db
+    league, commissioner, users = _seed_league(db, team_count=6)
+    app.dependency_overrides[divisions_router.get_current_user] = lambda: commissioner
+
+    _setup_manual_league(db, client, app, commissioner, league, users, team_count=6)
+
+    # Omit last user from assignments
+    partial = {
+        0: [u.id for u in users[:3]],
+        1: [u.id for u in users[3:5]],  # missing users[5]
+    }
+
+    res = client.post(
+        f"/leagues/{league.id}/divisions/assignment-preview",
+        json={
+            "season": 2026,
+            "assignment_method": "manual",
+            "manual_assignments": partial,
+        },
+    )
+    assert res.status_code == 422
+
+
+def test_manual_assignment_preview_rejects_duplicate_team_ids(client, api_db):
+    """manual_assignments with the same team in two divisions returns 422."""
+    db, _ = api_db
+    league, commissioner, users = _seed_league(db, team_count=6)
+    app.dependency_overrides[divisions_router.get_current_user] = lambda: commissioner
+
+    _setup_manual_league(db, client, app, commissioner, league, users, team_count=6)
+
+    duplicate_id = users[0].id
+    duplicated = {
+        0: [u.id for u in users[:3]],
+        1: [duplicate_id, users[3].id, users[4].id, users[5].id],  # users[0] duplicated
+    }
+
+    res = client.post(
+        f"/leagues/{league.id}/divisions/assignment-preview",
+        json={
+            "season": 2026,
+            "assignment_method": "manual",
+            "manual_assignments": duplicated,
+        },
+    )
+    assert res.status_code == 422
+
+
+def test_manual_assignment_preview_rejects_out_of_range_division_index(client, api_db):
+    """manual_assignments with a division index >= division_count returns 422."""
+    db, _ = api_db
+    league, commissioner, users = _seed_league(db, team_count=6)
+    app.dependency_overrides[divisions_router.get_current_user] = lambda: commissioner
+
+    _setup_manual_league(db, client, app, commissioner, league, users, team_count=6)
+
+    out_of_range = {
+        0: [u.id for u in users[:3]],
+        99: [u.id for u in users[3:]],  # division index 99 doesn't exist
+    }
+
+    res = client.post(
+        f"/leagues/{league.id}/divisions/assignment-preview",
+        json={
+            "season": 2026,
+            "assignment_method": "manual",
+            "manual_assignments": out_of_range,
+        },
+    )
+    assert res.status_code == 422
+
+
+def test_manual_assignment_preview_rejects_unknown_team_id(client, api_db):
+    """manual_assignments with a team_id not in the league returns 422."""
+    db, _ = api_db
+    league, commissioner, users = _seed_league(db, team_count=6)
+    app.dependency_overrides[divisions_router.get_current_user] = lambda: commissioner
+
+    _setup_manual_league(db, client, app, commissioner, league, users, team_count=6)
+
+    with_unknown = {
+        0: [u.id for u in users[:3]],
+        1: [999999, users[3].id, users[4].id],  # 999999 not in league, users[5] missing
+    }
+
+    res = client.post(
+        f"/leagues/{league.id}/divisions/assignment-preview",
+        json={
+            "season": 2026,
+            "assignment_method": "manual",
+            "manual_assignments": with_unknown,
+        },
+    )
+    assert res.status_code == 422
+
+
+def test_manual_assignment_preview_rejects_empty_manual_assignments(client, api_db):
+    """manual_assignments=None or {} returns 400."""
+    db, _ = api_db
+    league, commissioner, users = _seed_league(db, team_count=6)
+    app.dependency_overrides[divisions_router.get_current_user] = lambda: commissioner
+
+    _setup_manual_league(db, client, app, commissioner, league, users, team_count=6)
+
+    for empty_value in [None, {}]:
+        res = client.post(
+            f"/leagues/{league.id}/divisions/assignment-preview",
+            json={
+                "season": 2026,
+                "assignment_method": "manual",
+                "manual_assignments": empty_value,
+            },
+        )
+        assert res.status_code in (400, 422)

--- a/frontend/src/pages/commissioner/ManageDivisions.jsx
+++ b/frontend/src/pages/commissioner/ManageDivisions.jsx
@@ -92,6 +92,35 @@ export default function ManageDivisions() {
     return next;
   };
 
+  const validateManualAssignments = () => {
+    // Returns an error string if invalid, or null if valid.
+    const allOwnerIds = new Set(owners.map((o) => o.id));
+    const assignedIds = new Set();
+    const validIndices = new Set(Array.from({ length: divisionCount }, (_, i) => i));
+
+    for (const key of Object.keys(manualAssignments)) {
+      if (!validIndices.has(Number(key))) {
+        return `Division index ${key} is out of range (0..${divisionCount - 1}).`;
+      }
+      for (const id of manualAssignments[key]) {
+        if (assignedIds.has(id)) {
+          return `Team id ${id} is assigned to more than one division.`;
+        }
+        if (!allOwnerIds.has(id)) {
+          return `Team id ${id} does not belong to this league.`;
+        }
+        assignedIds.add(id);
+      }
+    }
+
+    const missing = [...allOwnerIds].filter((id) => !assignedIds.has(id));
+    if (missing.length > 0) {
+      return `${missing.length} team(s) are not assigned to any division. Assign all teams before proceeding.`;
+    }
+
+    return null;
+  };
+
   const loadContext = async (targetSeason = season) => {
     if (!leagueId) {
       setMessage('No active league selected.');
@@ -197,8 +226,9 @@ export default function ManageDivisions() {
       };
 
       if (assignmentMethod === 'manual') {
-        if (!manualAssignments || Object.keys(manualAssignments).length === 0) {
-          setMessage('Please select teams for each division before previewing.');
+        const validationError = validateManualAssignments();
+        if (validationError) {
+          setMessage(validationError);
           setPreviewing(false);
           return;
         }
@@ -230,6 +260,12 @@ export default function ManageDivisions() {
       };
 
       if (assignmentMethod === 'manual') {
+        const validationError = validateManualAssignments();
+        if (validationError) {
+          setMessage(validationError);
+          setFinalizing(false);
+          return;
+        }
         payload.manual_assignments = manualAssignments;
       }
 
@@ -403,11 +439,18 @@ export default function ManageDivisions() {
                             checked={isAssigned}
                             onChange={(e) => {
                               const next = { ...manualAssignments };
-                              if (!next[idx]) next[idx] = [];
+                              const currentAssignments = [...(next[idx] || [])];
                               if (e.target.checked) {
-                                next[idx].push(owner.id);
+                                next[idx] = currentAssignments.includes(owner.id)
+                                  ? currentAssignments
+                                  : [...currentAssignments, owner.id];
                               } else {
-                                next[idx] = next[idx].filter((id) => id !== owner.id);
+                                const filtered = currentAssignments.filter((id) => id !== owner.id);
+                                if (filtered.length > 0) {
+                                  next[idx] = filtered;
+                                } else {
+                                  delete next[idx];
+                                }
                               }
                               setManualAssignments(next);
                             }}

--- a/frontend/src/pages/commissioner/ManageDivisions.jsx
+++ b/frontend/src/pages/commissioner/ManageDivisions.jsx
@@ -44,6 +44,8 @@ export default function ManageDivisions() {
   const [assignmentMethod, setAssignmentMethod] = useState('heuristic');
   const [randomSeed, setRandomSeed] = useState('');
   const [names, setNames] = useState([]);
+  const [owners, setOwners] = useState([]);
+  const [manualAssignments, setManualAssignments] = useState({});
 
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -106,8 +108,9 @@ export default function ManageDivisions() {
         }),
       ]);
 
-      const owners = Array.isArray(ownersRes.data) ? ownersRes.data : [];
-      setOwnerCount(owners.length);
+      const ownersData = Array.isArray(ownersRes.data) ? ownersRes.data : [];
+      setOwners(ownersData);
+      setOwnerCount(ownersData.length);
 
       const cfg = configRes.data || {};
       const cfgSeason = Number(cfg.season || targetSeason);
@@ -187,13 +190,24 @@ export default function ManageDivisions() {
     setPreviewing(true);
     setMessage('');
     try {
+      const payload = {
+        season: Number(season),
+        assignment_method: assignmentMethod,
+        random_seed: randomSeed || null,
+      };
+
+      if (assignmentMethod === 'manual') {
+        if (!manualAssignments || Object.keys(manualAssignments).length === 0) {
+          setMessage('Please select teams for each division before previewing.');
+          setPreviewing(false);
+          return;
+        }
+        payload.manual_assignments = manualAssignments;
+      }
+
       const res = await apiClient.post(
         `/leagues/${leagueId}/divisions/assignment-preview`,
-        {
-          season: Number(season),
-          assignment_method: assignmentMethod,
-          random_seed: randomSeed || null,
-        }
+        payload
       );
       setPreview(res.data || null);
       setMessage('Preview generated. Review confidence and imbalance before finalizing.');
@@ -209,11 +223,17 @@ export default function ManageDivisions() {
     setFinalizing(true);
     setMessage('');
     try {
-      await apiClient.post(`/leagues/${leagueId}/divisions/finalize`, {
+      const payload = {
         season: Number(season),
         assignment_method: assignmentMethod,
         random_seed: randomSeed || null,
-      });
+      };
+
+      if (assignmentMethod === 'manual') {
+        payload.manual_assignments = manualAssignments;
+      }
+
+      await apiClient.post(`/leagues/${leagueId}/divisions/finalize`, payload);
       setMessage('Divisions finalized for the selected season.');
       await loadContext(season);
     } catch (err) {
@@ -339,9 +359,7 @@ export default function ManageDivisions() {
               disabled={!enabled}
               onChange={(e) => setAssignmentMethod(e.target.value)}
             >
-              <option value="manual" disabled>
-                Manual (coming soon)
-              </option>
+              <option value="manual">Manual (custom)</option>
               <option value="random">Random (seeded)</option>
               <option value="heuristic">Heuristic (deterministic)</option>
             </select>
@@ -360,6 +378,53 @@ export default function ManageDivisions() {
             />
           </div>
         </div>
+
+        {assignmentMethod === 'manual' && enabled && (
+          <div className="mt-6 pt-6 border-t border-slate-300 dark:border-slate-700">
+            <h3 className="text-sm font-bold text-slate-900 dark:text-white mb-3">
+              Manual Team Assignment
+            </h3>
+            <p className="text-xs text-slate-600 dark:text-slate-400 mb-4">
+              Select which teams should be assigned to each division. Each team must be assigned to exactly one division.
+            </p>
+            <div className="space-y-3">
+              {Array.from({ length: divisionCount }, (_, idx) => (
+                <div key={`manual-division-${idx}`} className="rounded-lg border border-slate-300 dark:border-slate-700 p-3">
+                  <div className="text-sm font-bold text-slate-900 dark:text-white mb-2">
+                    {names[idx]?.name || `Division ${idx + 1}`}
+                  </div>
+                  <div className="space-y-2">
+                    {owners.map((owner) => {
+                      const isAssigned = (manualAssignments[idx] || []).includes(owner.id);
+                      return (
+                        <label key={`checkbox-${idx}-${owner.id}`} className="flex items-center gap-2 text-sm cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={isAssigned}
+                            onChange={(e) => {
+                              const next = { ...manualAssignments };
+                              if (!next[idx]) next[idx] = [];
+                              if (e.target.checked) {
+                                next[idx].push(owner.id);
+                              } else {
+                                next[idx] = next[idx].filter((id) => id !== owner.id);
+                              }
+                              setManualAssignments(next);
+                            }}
+                            className="w-4 h-4"
+                          />
+                          <span className="text-slate-900 dark:text-white">
+                            {owner.team_name || owner.username}
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="mt-4">
           <div className="mb-2 text-sm font-bold text-slate-900 dark:text-white">Division Names</div>


### PR DESCRIPTION
## Summary

Enables Tier 2 of the stub audit (#423) by making the "Manual" division assignment option fully functional.

Previously, the manual option was disabled with "coming soon" text. This PR implements:

### Frontend
- **Remove disabled state**: Manual option is now selectable
- **Team-to-division UI**: When Manual is selected, displays checkboxes for each division allowing commissioners to select which teams go into each division
- **Validation**: Requires teams to be selected before preview/finalize
- **Payload handling**: Passes `manual_assignments` dict to preview and finalize endpoints

### Backend
- **Schema update**: Added `manual_assignments` field to `DivisionFinalizeRequest`
- **Flow**: Passes manual_assignments through finalize → preview pipeline
- **Processing**: Backend already had full support; this just connects the frontend inputs

## How to Test

1. Navigate to Commissioner → Manage Divisions
2. Enable divisions and select "Manual (custom)" from Assignment Method
3. You'll see a new "Manual Team Assignment" section with division buckets
4. Click checkboxes to assign teams to each division
5. Click "Preview Assignment" to see the balance metrics
6. Click "Approve & Finalize" to commit assignments

## Data Structure

Manual assignments payload:
```json
{
  "0": [1, 2, 3],    // Division 0 gets teams 1, 2, 3
  "1": [4, 5, 6],    // Division 1 gets teams 4, 5, 6
}
```

Closes #423 (Tier 2)