### PR TITLE
feat: League 60 owner backfill CLI tooling and workflow documentation (#341)

### DIFF
--- a/backend/manage.py
+++ b/backend/manage.py
@@ -34,6 +34,8 @@ from .scripts.validation.validate_mfl_import import run_validate_mfl_import, for
 from .scripts.validation.validate_season_hierarchy import run_validate_season_hierarchy, format_season_hierarchy_output
 from .scripts.validation.validate_league_readiness import run_validate_league_readiness, format_league_readiness_output
 import csv as _csv
+import io as _io
+import json as _json
 import os as _os
 from . import models
 
@@ -1303,6 +1305,296 @@ def validate_league_readiness_cmd(league_id: int):
     
     if summary["errors"]:
         raise click.ClickException("Validation failed with errors")
+
+
+# ====== HISTORY OWNER BACKFILL COMMANDS ======
+
+
+
+@cli.command("history-owner-gap-report")
+@click.option("--league-id", type=int, required=True, help="League ID to report on (e.g. 60 for Post Pacific League).")
+@click.option("--season", type=int, default=None, help="Limit report to a specific season year.")
+@click.option("--json-output", type=click.Path(dir_okay=False, writable=True), default=None, help="Write full JSON report to file.")
+def history_owner_gap_report(league_id: int, season: int | None, json_output: str | None):
+    """Print a summary of unresolved / placeholder historical owner mappings for a league.
+
+    Useful for diagnosing League 60 (Post Pacific League) enrichment gaps before running the
+    enrichment workflow via the commissioner UI or import-history-owner-seed command.
+    """
+    db = SessionLocal()
+    try:
+        league = db.query(models.League).filter(models.League.id == league_id).first()
+        if not league:
+            raise click.ClickException(f"League {league_id} not found in the database.")
+
+        q = db.query(models.LeagueHistoryTeamOwnerMap).filter(
+            models.LeagueHistoryTeamOwnerMap.league_id == league_id,
+        )
+        if season is not None:
+            q = q.filter(models.LeagueHistoryTeamOwnerMap.season == season)
+        all_rows = q.order_by(
+            models.LeagueHistoryTeamOwnerMap.season,
+            models.LeagueHistoryTeamOwnerMap.team_name,
+        ).all()
+
+        total = len(all_rows)
+        placeholder_rows = [
+            r for r in all_rows
+            if not r.owner_name or not r.owner_name.strip() or r.owner_name.strip() == (r.team_name or "").strip()
+        ]
+        resolved_rows = [r for r in all_rows if r not in placeholder_rows]
+
+        seasons_with_gaps = sorted({r.season for r in placeholder_rows})
+        seasons_fully_resolved = sorted({r.season for r in resolved_rows} - set(seasons_with_gaps))
+
+        click.echo(f"\nHistory Owner Gap Report — League {league_id} ({league.name})")
+        click.echo(f"{'=' * 60}")
+        click.echo(f"  Total mapped rows:   {total}")
+        click.echo(f"  Resolved rows:       {len(resolved_rows)}")
+        click.echo(f"  Placeholder rows:    {len(placeholder_rows)}")
+        if total > 0:
+            coverage = round(len(resolved_rows) / total * 100)
+            click.echo(f"  Coverage:            {coverage}%")
+        click.echo()
+
+        if placeholder_rows:
+            click.echo("Seasons with placeholder owner mappings:")
+            season_groups: dict[int, list] = {}
+            for r in placeholder_rows:
+                season_groups.setdefault(r.season, []).append(r)
+            for s in sorted(season_groups):
+                rows_s = season_groups[s]
+                click.echo(f"  {s}: {len(rows_s)} placeholder(s)")
+                for r in rows_s[:5]:
+                    click.echo(f"    id={r.id} team={r.team_name!r} owner={r.owner_name!r}")
+                if len(rows_s) > 5:
+                    click.echo(f"    ... and {len(rows_s) - 5} more")
+        else:
+            click.echo("No placeholder mappings found — all rows are resolved.")
+
+        if seasons_fully_resolved:
+            click.echo(f"\nFully resolved seasons: {seasons_fully_resolved}")
+
+        if json_output:
+            report = {
+                "league_id": league_id,
+                "league_name": league.name,
+                "total": total,
+                "resolved": len(resolved_rows),
+                "placeholders": len(placeholder_rows),
+                "placeholder_rows": [
+                    {
+                        "id": r.id,
+                        "season": r.season,
+                        "team_name": r.team_name,
+                        "owner_name": r.owner_name,
+                        "notes": r.notes,
+                    }
+                    for r in placeholder_rows
+                ],
+            }
+            with open(json_output, "w", encoding="utf-8") as fh:
+                _json.dump(report, fh, indent=2)
+            click.echo(f"\nFull report written to {json_output}")
+    finally:
+        db.close()
+
+
+@cli.command("export-history-owner-seed")
+@click.option("--league-id", type=int, required=True, help="League ID to export (e.g. 60).")
+@click.option("--output", type=click.Path(dir_okay=False, writable=True), required=True, help="Output CSV path.")
+@click.option("--placeholders-only", is_flag=True, default=False, help="Export only placeholder rows (default: all rows).")
+@click.option("--season", type=int, default=None, help="Limit export to a specific season year.")
+def export_history_owner_seed(league_id: int, output: str, placeholders_only: bool, season: int | None):
+    """Export league_history_team_owner_map rows to a CSV seed file.
+
+    The exported CSV can be edited offline (fill in owner_name / owner_id)
+    and re-imported via import-history-owner-seed or the commissioner UI at
+    /commissioner/history-owner-mapping.
+    """
+    db = SessionLocal()
+    try:
+        league = db.query(models.League).filter(models.League.id == league_id).first()
+        if not league:
+            raise click.ClickException(f"League {league_id} not found in the database.")
+
+        q = db.query(models.LeagueHistoryTeamOwnerMap).filter(
+            models.LeagueHistoryTeamOwnerMap.league_id == league_id,
+        )
+        if season is not None:
+            q = q.filter(models.LeagueHistoryTeamOwnerMap.season == season)
+        all_rows = q.order_by(
+            models.LeagueHistoryTeamOwnerMap.season,
+            models.LeagueHistoryTeamOwnerMap.team_name,
+        ).all()
+
+        if placeholders_only:
+            rows_to_export = [
+                r for r in all_rows
+                if not r.owner_name or not r.owner_name.strip() or r.owner_name.strip() == (r.team_name or "").strip()
+            ]
+        else:
+            rows_to_export = all_rows
+
+        fieldnames = ["id", "season", "team_name", "owner_name", "owner_id", "notes"]
+        with open(output, "w", newline="", encoding="utf-8") as fh:
+            writer = _csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writeheader()
+            for r in rows_to_export:
+                writer.writerow({
+                    "id": r.id,
+                    "season": r.season,
+                    "team_name": r.team_name,
+                    "owner_name": r.owner_name or "",
+                    "owner_id": r.owner_id or "",
+                    "notes": r.notes or ("placeholder - fill in real owner name" if not r.owner_name or r.owner_name.strip() == (r.team_name or "").strip() else ""),
+                })
+
+        click.echo(f"Exported {len(rows_to_export)} rows for league {league_id} ({league.name}) to {output}")
+        if placeholders_only:
+            click.echo("(placeholder rows only — edit owner_name / owner_id then re-import)")
+        else:
+            click.echo("(all rows — edit owner_name / owner_id for placeholder rows then re-import)")
+    finally:
+        db.close()
+
+
+@cli.command("import-history-owner-seed")
+@click.option("--league-id", type=int, required=True, help="League ID to import into.")
+@click.option("--csv", "csv_path", type=click.Path(file_okay=True, dir_okay=False, exists=True), required=True, help="Path to filled-in seed CSV (from export-history-owner-seed).")
+@click.option("--apply", "apply_changes", is_flag=True, default=False, help="Write to DB (default: dry-run).")
+def import_history_owner_seed(league_id: int, csv_path: str, apply_changes: bool):
+    """Import filled-in owner name mappings from a CSV seed file.
+
+    Reads a CSV produced by export-history-owner-seed (or the commissioner UI
+    export) where owner_name has been filled in, and upserts each row into
+    league_history_team_owner_map.
+
+    Rows with empty owner_name are skipped. Rows without an id are inserted as
+    new; rows with an id matching an existing record are updated.
+
+    Run without --apply for a dry-run preview first.
+    """
+    db = SessionLocal()
+    try:
+        league = db.query(models.League).filter(models.League.id == league_id).first()
+        if not league:
+            raise click.ClickException(f"League {league_id} not found in the database.")
+
+        with open(csv_path, newline="", encoding="utf-8") as fh:
+            reader = _csv.DictReader(fh)
+            rows = list(reader)
+
+        if not rows:
+            raise click.ClickException("CSV is empty — nothing to import.")
+
+        created = 0
+        updated = 0
+        skipped = 0
+        errors: list[str] = []
+
+        for i, row in enumerate(rows, start=2):  # row 1 = header
+            team_name = (row.get("team_name") or "").strip()
+            owner_name = (row.get("owner_name") or "").strip()
+            season_raw = (row.get("season") or "").strip()
+            row_id_raw = (row.get("id") or "").strip()
+            notes = (row.get("notes") or "").strip() or None
+
+            if not team_name:
+                errors.append(f"Row {i}: missing team_name — skipped")
+                skipped += 1
+                continue
+
+            if not owner_name or owner_name == team_name:
+                skipped += 1
+                continue
+
+            try:
+                season = int(season_raw)
+            except (ValueError, TypeError):
+                errors.append(f"Row {i}: invalid season {season_raw!r} — skipped")
+                skipped += 1
+                continue
+
+            owner_id: int | None = None
+            owner_id_raw = (row.get("owner_id") or "").strip()
+            if owner_id_raw:
+                try:
+                    owner_id = int(owner_id_raw)
+                    owner = db.query(models.User).filter(
+                        models.User.id == owner_id,
+                        models.User.league_id == league_id,
+                    ).first()
+                    if not owner:
+                        errors.append(f"Row {i}: owner_id {owner_id} not in league {league_id} — clearing owner_id")
+                        owner_id = None
+                except (ValueError, TypeError):
+                    errors.append(f"Row {i}: invalid owner_id {owner_id_raw!r} — clearing owner_id")
+                    owner_id = None
+
+            team_name_key = team_name.lower().strip()
+
+            existing = None
+            if row_id_raw:
+                try:
+                    existing = db.query(models.LeagueHistoryTeamOwnerMap).filter(
+                        models.LeagueHistoryTeamOwnerMap.id == int(row_id_raw),
+                        models.LeagueHistoryTeamOwnerMap.league_id == league_id,
+                    ).first()
+                except (ValueError, TypeError):
+                    pass
+
+            if existing is None:
+                existing = db.query(models.LeagueHistoryTeamOwnerMap).filter(
+                    models.LeagueHistoryTeamOwnerMap.league_id == league_id,
+                    models.LeagueHistoryTeamOwnerMap.season == season,
+                    models.LeagueHistoryTeamOwnerMap.team_name_key == team_name_key,
+                ).first()
+
+            action = "UPDATE" if existing else "INSERT"
+            click.echo(f"  [{action}] season={season} team={team_name!r} -> owner={owner_name!r}" + (f" owner_id={owner_id}" if owner_id else ""))
+
+            if apply_changes:
+                if existing:
+                    existing.owner_name = owner_name
+                    existing.owner_id = owner_id
+                    if notes:
+                        existing.notes = notes
+                    updated += 1
+                else:
+                    db.add(models.LeagueHistoryTeamOwnerMap(
+                        league_id=league_id,
+                        season=season,
+                        team_name=team_name,
+                        team_name_key=team_name_key,
+                        owner_name=owner_name,
+                        owner_id=owner_id,
+                        notes=notes,
+                    ))
+                    created += 1
+            else:
+                if existing:
+                    updated += 1
+                else:
+                    created += 1
+
+        if apply_changes:
+            db.commit()
+
+        mode_label = "applied" if apply_changes else "dry-run"
+        click.echo(f"\nImport complete ({mode_label}) — league {league_id} ({league.name})")
+        click.echo(f"  Rows read:   {len(rows)}")
+        click.echo(f"  Would insert / inserted: {created}")
+        click.echo(f"  Would update / updated:  {updated}")
+        click.echo(f"  Skipped (empty/placeholder owner): {skipped}")
+        if errors:
+            click.echo(f"\nWarnings ({len(errors)}):")
+            for e in errors:
+                click.echo(f"  {e}")
+        if not apply_changes:
+            click.echo("\nRe-run with --apply to commit changes to the database.")
+    finally:
+        db.close()
 
 
 if __name__ == "__main__":

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -34,10 +34,13 @@ from .scripts.validation.validate_mfl_import import run_validate_mfl_import, for
 from .scripts.validation.validate_season_hierarchy import run_validate_season_hierarchy, format_season_hierarchy_output
 from .scripts.validation.validate_league_readiness import run_validate_league_readiness, format_league_readiness_output
 import csv as _csv
-import io as _io
 import json as _json
 import os as _os
 from . import models
+from .services.league_history_enrichment_service import (
+    normalize_history_team_key as _normalize_history_team_key,
+    owner_label_is_placeholder as _owner_label_is_placeholder,
+)
 
 
 @click.group()
@@ -1340,7 +1343,7 @@ def history_owner_gap_report(league_id: int, season: int | None, json_output: st
         total = len(all_rows)
         placeholder_rows = [
             r for r in all_rows
-            if not r.owner_name or not r.owner_name.strip() or r.owner_name.strip() == (r.team_name or "").strip()
+            if not (r.owner_name or "").strip() or _owner_label_is_placeholder(r.owner_name, r.team_name)
         ]
         resolved_rows = [r for r in all_rows if r not in placeholder_rows]
 
@@ -1431,7 +1434,7 @@ def export_history_owner_seed(league_id: int, output: str, placeholders_only: bo
         if placeholders_only:
             rows_to_export = [
                 r for r in all_rows
-                if not r.owner_name or not r.owner_name.strip() or r.owner_name.strip() == (r.team_name or "").strip()
+                if not (r.owner_name or "").strip() or _owner_label_is_placeholder(r.owner_name, r.team_name)
             ]
         else:
             rows_to_export = all_rows
@@ -1532,7 +1535,7 @@ def import_history_owner_seed(league_id: int, csv_path: str, apply_changes: bool
                     errors.append(f"Row {i}: invalid owner_id {owner_id_raw!r} — clearing owner_id")
                     owner_id = None
 
-            team_name_key = team_name.lower().strip()
+            team_name_key = _normalize_history_team_key(team_name)
 
             existing = None
             if row_id_raw:
@@ -1556,10 +1559,11 @@ def import_history_owner_seed(league_id: int, csv_path: str, apply_changes: bool
 
             if apply_changes:
                 if existing:
+                    existing.team_name = team_name
+                    existing.team_name_key = team_name_key
                     existing.owner_name = owner_name
                     existing.owner_id = owner_id
-                    if notes:
-                        existing.notes = notes
+                    existing.notes = notes
                     updated += 1
                 else:
                     db.add(models.LeagueHistoryTeamOwnerMap(

--- a/backend/tests/test_manage_history_owner_cli.py
+++ b/backend/tests/test_manage_history_owner_cli.py
@@ -1,0 +1,379 @@
+"""Tests for history owner backfill CLI commands in backend/manage.py."""
+
+from unittest.mock import MagicMock, patch
+import csv
+import tempfile
+import os
+
+from click.testing import CliRunner
+
+import backend.manage as manage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_league(league_id=60, name="Post Pacific League"):
+    league = MagicMock()
+    league.id = league_id
+    league.name = name
+    return league
+
+
+def _make_row(id, season, team_name, owner_name=None, owner_id=None, notes=None):
+    row = MagicMock()
+    row.id = id
+    row.season = season
+    row.team_name = team_name
+    row.owner_name = owner_name
+    row.owner_id = owner_id
+    row.notes = notes
+    return row
+
+
+# ---------------------------------------------------------------------------
+# history-owner-gap-report
+# ---------------------------------------------------------------------------
+
+class TestHistoryOwnerGapReport:
+    def _invoke(self, db_session, *extra_args):
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db_session):
+            return runner.invoke(manage.cli, ["history-owner-gap-report"] + list(extra_args))
+
+    def _make_db(self, league, rows):
+        db = MagicMock()
+        db.__enter__ = lambda s: s
+        db.__exit__ = MagicMock(return_value=False)
+        q = MagicMock()
+        q.filter.return_value = q
+        q.order_by.return_value = q
+        q.all.return_value = rows
+        db.query.side_effect = lambda model: league if model.__name__ == "League" else q
+        # league lookup
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.order_by.return_value = map_q
+        map_q.all.return_value = rows
+
+        def query_side_effect(model):
+            if hasattr(model, "__tablename__") and model.__tablename__ == "leagues":
+                return league_q
+            return map_q
+
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+        return db
+
+    def test_missing_required_league_id(self):
+        runner = CliRunner()
+        result = runner.invoke(manage.cli, ["history-owner-gap-report"])
+        assert result.exit_code != 0
+        assert "--league-id" in result.output or "Missing option" in result.output
+
+    def test_league_not_found(self):
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = None
+        db.query = MagicMock(return_value=league_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            result = runner.invoke(manage.cli, ["history-owner-gap-report", "--league-id", "999"])
+
+        assert result.exit_code != 0
+        assert "999" in result.output
+
+    def test_all_resolved(self):
+        league = _make_league()
+        rows = [
+            _make_row(1, 2020, "Team A", "Jane Smith"),
+            _make_row(2, 2020, "Team B", "John Doe"),
+        ]
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.order_by.return_value = map_q
+        map_q.all.return_value = rows
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            result = runner.invoke(manage.cli, ["history-owner-gap-report", "--league-id", "60"])
+
+        assert result.exit_code == 0
+        assert "No placeholder mappings found" in result.output
+        assert "Resolved rows:       2" in result.output
+
+    def test_placeholder_rows_reported(self):
+        league = _make_league()
+        # row where owner_name == team_name is a placeholder
+        rows = [
+            _make_row(1, 2020, "Team A", "Team A"),
+            _make_row(2, 2020, "Team B", "Jane Smith"),
+        ]
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.order_by.return_value = map_q
+        map_q.all.return_value = rows
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            result = runner.invoke(manage.cli, ["history-owner-gap-report", "--league-id", "60"])
+
+        assert result.exit_code == 0
+        assert "Placeholder rows:    1" in result.output
+        assert "Resolved rows:       1" in result.output
+
+    def test_json_output_written(self):
+        league = _make_league()
+        rows = [_make_row(1, 2020, "Team A", "Team A")]
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.order_by.return_value = map_q
+        map_q.all.return_value = rows
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            with runner.isolated_filesystem():
+                result = runner.invoke(
+                    manage.cli,
+                    ["history-owner-gap-report", "--league-id", "60", "--json-output", "out.json"],
+                )
+                assert result.exit_code == 0
+                assert os.path.exists("out.json")
+                import json
+                data = json.loads(open("out.json").read())
+                assert data["league_id"] == 60
+                assert data["placeholders"] == 1
+
+
+# ---------------------------------------------------------------------------
+# export-history-owner-seed
+# ---------------------------------------------------------------------------
+
+class TestExportHistoryOwnerSeed:
+    def test_missing_league_id(self):
+        runner = CliRunner()
+        result = runner.invoke(manage.cli, ["export-history-owner-seed", "--output", "/tmp/x.csv"])
+        assert result.exit_code != 0
+
+    def test_missing_output(self):
+        runner = CliRunner()
+        result = runner.invoke(manage.cli, ["export-history-owner-seed", "--league-id", "60"])
+        assert result.exit_code != 0
+
+    def test_exports_all_rows(self):
+        league = _make_league()
+        rows = [
+            _make_row(1, 2020, "Team A", "Jane Smith"),
+            _make_row(2, 2020, "Team B", "Team B"),
+        ]
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.order_by.return_value = map_q
+        map_q.all.return_value = rows
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            with runner.isolated_filesystem():
+                result = runner.invoke(
+                    manage.cli,
+                    ["export-history-owner-seed", "--league-id", "60", "--output", "seed.csv"],
+                )
+                assert result.exit_code == 0
+                assert "Exported 2 rows" in result.output
+                with open("seed.csv") as fh:
+                    reader = csv.DictReader(fh)
+                    exported = list(reader)
+                assert len(exported) == 2
+
+    def test_placeholders_only_filter(self):
+        league = _make_league()
+        rows = [
+            _make_row(1, 2020, "Team A", "Jane Smith"),
+            _make_row(2, 2020, "Team B", "Team B"),  # placeholder
+            _make_row(3, 2020, "Team C", None),        # empty = placeholder
+        ]
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.order_by.return_value = map_q
+        map_q.all.return_value = rows
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            with runner.isolated_filesystem():
+                result = runner.invoke(
+                    manage.cli,
+                    ["export-history-owner-seed", "--league-id", "60", "--output", "seed.csv", "--placeholders-only"],
+                )
+                assert result.exit_code == 0
+                assert "Exported 2 rows" in result.output
+
+
+# ---------------------------------------------------------------------------
+# import-history-owner-seed
+# ---------------------------------------------------------------------------
+
+class TestImportHistoryOwnerSeed:
+    def _write_csv(self, path, rows):
+        fieldnames = ["id", "season", "team_name", "owner_name", "owner_id", "notes"]
+        with open(path, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writeheader()
+            for r in rows:
+                writer.writerow(r)
+
+    def test_dry_run_by_default(self):
+        """--apply not passed means dry-run: no db.commit() called."""
+        league = _make_league()
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.first.return_value = None
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            with runner.isolated_filesystem():
+                self._write_csv("seed.csv", [
+                    {"id": "", "season": "2020", "team_name": "Team A", "owner_name": "Jane Smith", "owner_id": "", "notes": ""},
+                ])
+                result = runner.invoke(
+                    manage.cli,
+                    ["import-history-owner-seed", "--league-id", "60", "--csv", "seed.csv"],
+                )
+
+        assert result.exit_code == 0
+        assert "dry-run" in result.output
+        assert "Re-run with --apply" in result.output
+        db.commit.assert_not_called()
+
+    def test_apply_commits(self):
+        league = _make_league()
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.first.return_value = None
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            with runner.isolated_filesystem():
+                self._write_csv("seed.csv", [
+                    {"id": "", "season": "2020", "team_name": "Team A", "owner_name": "Jane Smith", "owner_id": "", "notes": ""},
+                ])
+                result = runner.invoke(
+                    manage.cli,
+                    ["import-history-owner-seed", "--league-id", "60", "--csv", "seed.csv", "--apply"],
+                )
+
+        assert result.exit_code == 0
+        assert "applied" in result.output
+        db.commit.assert_called_once()
+
+    def test_skips_empty_owner_name(self):
+        league = _make_league()
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.first.return_value = None
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            with runner.isolated_filesystem():
+                self._write_csv("seed.csv", [
+                    {"id": "", "season": "2020", "team_name": "Team A", "owner_name": "", "owner_id": "", "notes": ""},
+                ])
+                result = runner.invoke(
+                    manage.cli,
+                    ["import-history-owner-seed", "--league-id", "60", "--csv", "seed.csv"],
+                )
+
+        assert result.exit_code == 0
+        assert "Skipped" in result.output
+
+    def test_update_clears_notes_when_empty(self):
+        """When notes is empty in CSV, the existing row's notes should be set to None (cleared)."""
+        league = _make_league()
+        existing = _make_row(1, 2020, "Team A", "Team A", notes="old note")
+
+        db = MagicMock()
+        db.close = MagicMock()
+        league_q = MagicMock()
+        league_q.filter.return_value = league_q
+        league_q.first.return_value = league
+        # first query by id returns existing; second by key also returns existing
+        map_q = MagicMock()
+        map_q.filter.return_value = map_q
+        map_q.first.return_value = existing
+        db.query = MagicMock(side_effect=lambda m: league_q if m is manage.models.League else map_q)
+
+        runner = CliRunner()
+        with patch("backend.manage.SessionLocal", return_value=db):
+            with runner.isolated_filesystem():
+                self._write_csv("seed.csv", [
+                    {"id": "1", "season": "2020", "team_name": "Team A", "owner_name": "Jane Smith", "owner_id": "", "notes": ""},
+                ])
+                result = runner.invoke(
+                    manage.cli,
+                    ["import-history-owner-seed", "--league-id", "60", "--csv", "seed.csv", "--apply"],
+                )
+
+        assert result.exit_code == 0
+        # notes should have been set to None (empty CSV value clears the field)
+        assert existing.notes is None
+
+    def test_missing_league_id_option(self):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("seed.csv", "w") as f:
+                f.write("id,season,team_name,owner_name,owner_id,notes\n")
+            result = runner.invoke(manage.cli, ["import-history-owner-seed", "--csv", "seed.csv"])
+        assert result.exit_code != 0

--- a/docs/LEAGUE60_OWNER_BACKFILL.md
+++ b/docs/LEAGUE60_OWNER_BACKFILL.md
@@ -1,0 +1,145 @@
+# League 60 Historical Owner Backfill Workflow
+
+**Related issues:** #341, #313, #314, #316
+
+## Background
+
+League 60 (Post Pacific League) has historical seasons dating back to 2002. For many earlier seasons the MFL API franchise export stores `owner_name == franchise_name`, meaning no true person-identity is recorded in the source data.
+
+The enrichment infrastructure (API endpoints, commissioner UI, diagnostics) was delivered in issues #313–#316. This document describes how to use those tools to enumerate and fix the remaining placeholder mappings.
+
+## Why placeholders exist
+
+When `extract-mfl-history` pulls franchise records from the MFL API, it stores whatever the API returns as `owner_name`. For older League 60 seasons the MFL API only had the team/franchise name available — no person name. The pipeline detects this condition (`owner_name == team_name`) and suppresses those values from UI display, leaving the rows as "unresolved."
+
+## Prerequisites
+
+- Python venv activated: `source .venv/bin/activate`
+- Backend environment loaded (`.env` or equivalent with `DATABASE_URL` pointing at the target DB)
+- Commissioner access (for UI workflow) or direct DB access (for CLI workflow)
+
+---
+
+## Step 1 — Enumerate gaps
+
+### Via CLI
+
+```bash
+python -m backend.manage history-owner-gap-report --league-id 60
+```
+
+This prints a season-by-season summary of placeholder rows. Add `--json-output gaps.json` to get the full list.
+
+### Via API / UI
+
+Navigate to the commissioner panel → **History Owner Mapping** (route `/commissioner/history-owner-mapping?leagueId=60`). The gap summary cards show placeholder count, unresolved match teams, and unresolved series teams.
+
+---
+
+## Step 2 — Export a seed CSV
+
+```bash
+python -m backend.manage export-history-owner-seed \
+    --league-id 60 \
+    --output /tmp/league60_owners.csv \
+    --placeholders-only
+```
+
+The output CSV has columns: `id, season, team_name, owner_name, owner_id, notes`.
+
+- `id` — existing DB row id; leave as-is so the importer can update rather than duplicate.
+- `owner_name` — fill in the real person name (e.g. `"Jane Smith"`).
+- `owner_id` — optionally link to a `users.id` in the same league for cross-reference queries.
+- Leave `owner_name` blank for any rows you can't confirm — they will be skipped on import.
+
+Alternatively, download the same CSV from the commissioner UI's **Export seed CSV** button.
+
+---
+
+## Step 3 — Fill in owner names
+
+Edit the exported CSV. Data sources for League 60 owners:
+
+| Season range | Suggested source |
+|---|---|
+| 2002–2010 | Original league organizer records / email archives |
+| 2011–2022 | MFL franchise page (if updated) or league member self-report |
+| 2023–present | Current `users` table — match by `team_name` |
+
+For the current active members you can cross-reference:
+
+```sql
+SELECT id, username, team_name FROM users WHERE league_id = 60 ORDER BY team_name;
+```
+
+---
+
+## Step 4 — Dry-run the import
+
+```bash
+python -m backend.manage import-history-owner-seed \
+    --league-id 60 \
+    --csv /tmp/league60_owners_filled.csv
+```
+
+Review the printed `[UPDATE]` / `[INSERT]` lines. Warnings about invalid `owner_id` values or malformed rows are printed but do not abort the run.
+
+---
+
+## Step 5 — Apply the import
+
+```bash
+python -m backend.manage import-history-owner-seed \
+    --league-id 60 \
+    --csv /tmp/league60_owners_filled.csv \
+    --apply
+```
+
+Alternatively, use the commissioner UI's **Upload seed CSV** button which calls the same upsert endpoint.
+
+---
+
+## Step 6 — Verify in League History
+
+After importing, visit:
+
+- **League History → Match Records** — owner names should appear for enriched seasons.
+- **League History → All-Time Series** — perspective/opponent owner columns should be resolved.
+- **History Owner Mapping** commissioner page — placeholder count should drop.
+
+Re-run the gap report to confirm:
+
+```bash
+python -m backend.manage history-owner-gap-report --league-id 60
+```
+
+---
+
+## Repeating for additional seasons
+
+The workflow is fully repeatable:
+
+1. Export remaining placeholders (`--placeholders-only`).
+2. Fill in what you can.
+3. Dry-run → apply.
+4. Verify.
+
+Rows with empty `owner_name` in the CSV are skipped without error, so partial fills are safe.
+
+---
+
+## Data sources used (to be updated as seasons are enriched)
+
+| Season | Status | Source | Notes |
+|---|---|---|---|
+| *(none yet)* | Pending | — | Run workflow to begin enrichment |
+
+Update this table as seasons are enriched so future maintainers know which seasons have been verified.
+
+---
+
+## Remaining known gaps
+
+- The MFL API does not expose historical person-name ownership for franchises that changed hands before MFL began tracking it.
+- For very early seasons (2002–2006) the only reliable source is league organizer memory or external records.
+- Seasons with no matchup records in `mfl_html_record_facts` cannot produce unresolved match/series entries even if owner identity is unknown.


### PR DESCRIPTION
## Summary

Closes #341

Adds CLI management commands and documentation to support the League 60 historical owner identity backfill workflow.

## Background

League 60 (Post Pacific League) has placeholder owner mappings where `owner_name == team_name` for many historical seasons. The enrichment platform (API, commissioner UI, diagnostics) was already built in #313-#316. This PR adds the missing CLI tooling for the backfill data operation itself.

## Changes

### `backend/manage.py` — three new commands

| Command | Purpose |
|---|---|
| `history-owner-gap-report --league-id` | Print season-level placeholder summary; optional `--json-output` |
| `export-history-owner-seed --league-id --output` | Export fillable CSV of owner map rows (`--placeholders-only` flag) |
| `import-history-owner-seed --league-id --csv` | Upsert filled CSV into DB; dry-run by default, `--apply` to commit |

### `docs/LEAGUE60_OWNER_BACKFILL.md`

Step-by-step enrichment workflow: enumerate -> export -> fill -> dry-run -> apply -> verify. Includes data source guidance, SQL helpers for cross-referencing current users, and a status tracking table for future maintainers.

## Acceptance criteria coverage

- [x] League 60 unresolved rows enumerable with season-level diagnostics -> `history-owner-gap-report`
- [x] Placeholder mappings distinguishable from valid -> existing gap service + suppression logic (unchanged)
- [x] Repeatable enrichment/backfill workflow -> `export` + `import` commands documented end-to-end
- [ ] At least one verified League 60 sample season enriched end-to-end -> data operation; must be run on production following this workflow
- [x] Documentation records data sources and remaining gaps -> `LEAGUE60_OWNER_BACKFILL.md`

> AC 4 requires running the workflow against the production database where League 60 data lives. The local dev DB only has the seeded test league. The tooling is ready; enrichment happens at ops time.

## Testing

```bash
# Verify commands are registered
python -m backend.manage --help | grep -E 'history-owner|export-history|import-history'

# Dry-run against any league id in dev DB (e.g. league 1)
python -m backend.manage history-owner-gap-report --league-id 1
python -m backend.manage export-history-owner-seed --league-id 1 --output /tmp/seed.csv
python -m backend.manage import-history-owner-seed --league-id 1 --csv /tmp/seed.csv
```
