### PR TITLE
feat: Phase 2 local pre-PR check rollout (#373)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# .githooks/pre-push
+#
+# Runs the local pre-PR gate before every `git push`.
+# Skips if pushing to a branch named 'main' directly (rare; CI covers that).
+#
+# To install: run  scripts/setup-hooks.sh  once after cloning.
+# To bypass one-off: git push --no-verify
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$REPO_ROOT/tests/local_pre_pr_check.sh"
+
+# Read the remote/URL passed by git (stdin not needed here; we use positional args)
+REMOTE="$1"
+# URL is $2 but we only need it to detect pushes to origin
+
+# Don't block pushes that only touch remote refs we can't diff locally
+# (e.g. deleting a remote branch).
+while read local_ref local_sha remote_ref remote_sha; do
+    # Skip branch deletion pushes
+    if [[ "$local_sha" == "0000000000000000000000000000000000000000" ]]; then
+        continue
+    fi
+
+    # Determine the branch name being pushed
+    BRANCH="${local_ref#refs/heads/}"
+
+    # Skip direct pushes to main (shouldn't happen in normal workflow, but be safe)
+    if [[ "$BRANCH" == "main" ]]; then
+        echo "[pre-push] Pushing to main — skipping local gate (CI enforces)."
+        continue
+    fi
+
+    echo ""
+    echo "[pre-push] Running local pre-PR gate (mode: changed)..."
+    echo "[pre-push] To skip: git push --no-verify"
+    echo ""
+
+    if [[ ! -f "$GATE" ]]; then
+        echo "[pre-push] WARNING: $GATE not found — skipping gate."
+        continue
+    fi
+
+    if ! bash "$GATE" changed; then
+        echo ""
+        echo "[pre-push] Pre-push gate FAILED. Fix issues above or use --no-verify to bypass."
+        exit 1
+    fi
+
+done
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,7 +9,9 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Use git to find the repo root — works correctly whether the hook lives in
+# .githooks/ (source) or .git/hooks/ (after installation via setup-hooks.sh).
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 GATE="$REPO_ROOT/tests/local_pre_pr_check.sh"
 
 # Read the remote/URL passed by git (stdin not needed here; we use positional args)
@@ -18,9 +20,16 @@ REMOTE="$1"
 
 # Don't block pushes that only touch remote refs we can't diff locally
 # (e.g. deleting a remote branch).
+GATE_SHOULD_RUN=false
+
 while read local_ref local_sha remote_ref remote_sha; do
     # Skip branch deletion pushes
     if [[ "$local_sha" == "0000000000000000000000000000000000000000" ]]; then
+        continue
+    fi
+
+    # Only handle branch refs (refs/heads/*); skip tags, notes, etc.
+    if [[ "$local_ref" != refs/heads/* ]]; then
         continue
     fi
 
@@ -33,6 +42,13 @@ while read local_ref local_sha remote_ref remote_sha; do
         continue
     fi
 
+    # Mark that at least one non-main branch ref warrants running the gate
+    GATE_SHOULD_RUN=true
+
+done
+
+# Run the gate at most once per push (even if multiple branch refs were pushed)
+if [[ "$GATE_SHOULD_RUN" == "true" ]]; then
     echo ""
     echo "[pre-push] Running local pre-PR gate (mode: changed)..."
     echo "[pre-push] To skip: git push --no-verify"
@@ -40,7 +56,7 @@ while read local_ref local_sha remote_ref remote_sha; do
 
     if [[ ! -f "$GATE" ]]; then
         echo "[pre-push] WARNING: $GATE not found — skipping gate."
-        continue
+        exit 0
     fi
 
     if ! bash "$GATE" changed; then
@@ -48,7 +64,6 @@ while read local_ref local_sha remote_ref remote_sha; do
         echo "[pre-push] Pre-push gate FAILED. Fix issues above or use --no-verify to bypass."
         exit 1
     fi
-
-done
+fi
 
 exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
           # Frontend: *.test.{js,jsx,ts,tsx} under frontend/tests/ OR Cypress specs.
           # Backend:  test_*.py or conftest.py under backend/tests/.
           # ETL:      test_*.py at etl root or any subdirectory.
+          # Shell/other: tests/test_* at repo root tests/ dir (e.g. test_setup_hooks.sh).
           TEST_DELTA=$(echo "$CHANGED" | grep -E \
-            '(^frontend/tests/.*\.test\.[jt]sx?$|^frontend/cypress/e2e/.*\.spec\.[jt]sx?$|^backend/tests/(test_|conftest)|^etl/.*test_)' \
+            '(^frontend/tests/.*\.test\.[jt]sx?$|^frontend/cypress/e2e/.*\.spec\.[jt]sx?$|^backend/tests/(test_|conftest)|^etl/.*test_|^tests/test_)' \
             || true)
 
           if [ -z "$TEST_DELTA" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,20 +194,20 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
      feature folders (for example `src/pages/commissioner/`) rather than
      introducing ad-hoc top-level folders.
 
-2. **Audit critical pages.**
+3. **Audit critical pages.**
    - Before adding new UI (e.g. Taxi Squad) or touching existing logic
      (LineupRules, WaiverRules, etc.), set breakpoints in each module’s
      fetch hooks and handlers as described above and walk through them using
      the VS Code debugger. Capture a screenshot of the _Variables_ pane for
      at least one component to prove the audit was done.
 
-3. **Keep docs and route matrices synchronized.**
+4. **Keep docs and route matrices synchronized.**
    - Any new page, endpoint surface, or major integration should be reflected
      in `docs/API_PAGE_MATRIX.md` and linked from `docs/INDEX.md`.
    - If docs in `docs/` change, ensure index updates are included in the same
      PR.
 
-4. **UAT artifacts must be updated with every feature or behavior change.**
+5. **UAT artifacts must be updated with every feature or behavior change.**
    - Any new feature, workflow change, validation rule, or UI behavior update
      must include matching updates in `docs/uat/uat_master.xlsx` and
      `docs/uat/uat_overview.pptx` in the same PR.
@@ -221,11 +221,11 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
      `docs/uat/UAT_MASTER_DOCUMENT_INSTRUCTIONS.md` when policy/process needs
      clarification.
 
-5. **Follow the DoD on every PR.** Any pull request lacking one of the three
+6. **Follow the DoD on every PR.** Any pull request lacking one of the three
    DoD checks (tests, debugger walkthrough, clean console) should be
    rejected until the developer demonstrates compliance.
 
-6. **PR review gate: UAT sync check.**
+7. **PR review gate: UAT sync check.**
    - Reviewers should reject PRs with user-facing changes if UAT artifacts were
      not updated.
    - Minimum expected evidence in PR description:
@@ -234,7 +234,7 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
      - whether `Execution Tier` changed for impacted scenarios
      - any new entries added to `Defect_Rollup` template fields if applicable
 
-7. **Workflow YAML hygiene gate (new standard).**
+8. **Workflow YAML hygiene gate (new standard).**
    - Any edit under `.github/workflows/*.yml` must be made in the actual tracked file,
      not a temporary chat/editor buffer.
    - Before commit, verify workflow structure with:
@@ -247,7 +247,7 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
    - PRs that modify workflows should include a brief note that YAML structure was
      reviewed and CI syntax is valid.
 
-8. **Issue triage checklist (required before merge).**
+9. **Issue triage checklist (required before merge).**
    - Confirm whether each issue touched by the PR is:
      - `Resolved in code and ready to close`, or
      - `Still open with remaining implementation work`.
@@ -262,7 +262,7 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
      - `Pending close:` list
      - `Net new:` list
 
-9. **PR feedback closure gate (required before merge/issue close).**
+10. **PR feedback closure gate (required before merge/issue close).**
    - Before merging any PR and before closing linked issues, confirm review feedback is resolved.
    - Required checks:
      - `gh pr view <PR_NUMBER> --repo NPGrant81/fantasy-football-pi --json comments,reviews,reviewDecision`
@@ -271,7 +271,7 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
      - If any actionable thread remains unresolved (`isResolved=false` and not outdated), do not merge yet.
      - Either address it in follow-up commits or explicitly defer it with rationale in PR comments before merge.
 
-10. **Branch/worktree lifecycle policy (required after merge).**
+11. **Branch/worktree lifecycle policy (required after merge).**
    - For merged or obsolete PRs, retire the branch/worktree set:
      - delete remote topic branch (when policy allows)
      - remove local worktree tied to that topic branch
@@ -280,7 +280,7 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
    - Reopen an old PR only when it was closed by mistake and the work scope is unchanged.
    - In follow-up PRs, include cross-links to previous PRs/issues for historical context.
 
-11. **Issue status transition policy (required while work is active).**
+12. **Issue status transition policy (required while work is active).**
    - Use these canonical status transitions for every issue touched by a PR:
      - `To Do` -> `In Progress` when implementation starts (first code, test, or docs commit tied to the issue)
      - `In Progress` -> `Complete` when acceptance criteria are met and validation evidence is posted
@@ -291,7 +291,7 @@ SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
      - Update `docs/ISSUE_STATUS.md` with implementation state and close-out note reference.
      - Reflect the transition in the PR `Issue Hygiene` section (`Closed`, `Pending close`, `Net new`).
 
-  12. **Cross-platform startup parity gate (required for dev startup/docs changes).**
+  13. **Cross-platform startup parity gate (required for dev startup/docs changes).**
      - If a PR changes local startup behavior, startup scripts, or startup documentation,
        validate Linux and Windows flows remain equivalent.
      - Required scope for parity changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,9 +125,69 @@ hit breakpoints as you interact with the UI.
 
 ---
 
+## Local Pre-PR Gate (Phase 2 of testing epic #370)
+
+Run this before pushing a branch or opening a PR. It mirrors the CI checks so
+failures are caught locally instead of in the pipeline.
+
+### Quick start
+
+```bash
+# Normal work — tests only the lanes with changed files (fast):
+bash tests/local_pre_pr_check.sh changed
+
+# Risky changes (e.g. schema migrations, cross-cutting refactors) — all lanes:
+bash tests/local_pre_pr_check.sh full
+
+# All lanes + E2E (once #375 is implemented):
+bash tests/local_pre_pr_check.sh full --with-e2e
+```
+
+### Automatic hook (recommended)
+
+Install a `pre-push` git hook so the `changed` check runs automatically on
+every push without having to remember:
+
+```bash
+bash scripts/setup-hooks.sh
+```
+
+This copies `.githooks/pre-push` into `.git/hooks/`. The hook:
+- Runs `tests/local_pre_pr_check.sh changed` before any push to a non-`main` branch.
+- Skips pushes directly to `main` (rare; CI covers that path).
+- Can be bypassed for a single push with `git push --no-verify`.
+
+To uninstall: `rm .git/hooks/pre-push`
+
+### When to use each mode
+
+| Situation | Command |
+|---|---|
+| Everyday feature/bugfix work | `changed` (default) |
+| Schema migration, auth change, cross-cutting refactor | `full` |
+| Final check before a release branch PR | `full --with-e2e` (requires #375) |
+
+### Environment overrides
+
+Set these to skip individual lanes when you know they're unaffected:
+
+```bash
+SKIP_BACKEND=1 bash tests/local_pre_pr_check.sh changed   # skip backend pytest
+SKIP_FRONTEND=1 bash tests/local_pre_pr_check.sh changed  # skip frontend vitest
+SKIP_ETL=1 bash tests/local_pre_pr_check.sh changed       # skip ETL pytest
+```
+
+---
+
 ## Current Action Items
 
-1. **Maintain naming and structure hygiene.**
+1. **Run the local pre-PR gate before every push.**
+   - Install the hook once: `bash scripts/setup-hooks.sh`
+   - Or run manually: `bash tests/local_pre_pr_check.sh changed`
+   - For risky changes (migrations, cross-cutting refactors): `bash tests/local_pre_pr_check.sh full`
+   - The gate mirrors CI — catching failures locally is faster than waiting for the pipeline.
+
+2. **Maintain naming and structure hygiene.**
    - Keep React component filenames in PascalCase and avoid case-only name
      differences in tracked files.
    - If you add a new route page or major module, place it under the existing

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ Refer to the appropriate file for more information.
 - [Frontend Ui Standards](FRONTEND_UI_STANDARDS.md)
 - [Issue 112 Execution Plan](ISSUE_112_EXECUTION_PLAN.md)
 - [Issue Status](ISSUE_STATUS.md)
+- [League 60 Historical Owner Backfill Workflow](LEAGUE60_OWNER_BACKFILL.md)
 - [Live Scoring Reliability Runbook](LIVE_SCORING_RELIABILITY_RUNBOOK.md)
 - [Mfl Historical Data Operations](MFL_HISTORICAL_DATA_OPERATIONS.md)
 - [Model-Serving-And-Integration](model-serving-and-integration.md)

--- a/docs/governance/doc_review_registry.json
+++ b/docs/governance/doc_review_registry.json
@@ -24,6 +24,12 @@
     "last_reviewed": "2026-04-27"
   },
   {
+    "path": "docs/LEAGUE60_OWNER_BACKFILL.md",
+    "owner": "data",
+    "cadence_days": 60,
+    "last_reviewed": "2026-04-27"
+  },
+  {
     "path": "docs/FRONTEND_UI_STANDARDS.md",
     "owner": "frontend",
     "cadence_days": 60,

--- a/scripts/repo_hygiene_check.py
+++ b/scripts/repo_hygiene_check.py
@@ -97,7 +97,7 @@ def _classify_doc_path(rel_path: str) -> tuple[str, str] | None:
         return ("platform", "operations")
     if any(token in name for token in ["security", "permissions"]):
         return ("security", "policy")
-    if any(token in name for token in ["data", "scoring", "validation", "dictionary", "monte-carlo", "mfl_", "cross_module_edge_case", "db_migration_phase1"]):
+    if any(token in name for token in ["data", "scoring", "validation", "dictionary", "monte-carlo", "mfl_", "cross_module_edge_case", "db_migration_phase1", "owner_backfill"]):
         return ("data", "data-contract-or-quality")
     if any(token in name for token in ["pattern", "governance", "doc_issue", "documentation_update", "testing_session_summary", "dependency_maintenance", "dev-environment"]):
         return ("governance", "process")

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -38,10 +38,18 @@ for hook_src in "$HOOKS_SRC"/*; do
     hook_name="$(basename "$hook_src")"
     hook_dst="$HOOKS_DST/$hook_name"
 
+    # Skip backup+copy if the destination already matches the source (idempotent)
+    if [[ -f "$hook_dst" ]] && cmp -s "$hook_src" "$hook_dst"; then
+        echo "  Already up-to-date: $hook_name"
+        ((SKIPPED++)) || true
+        continue
+    fi
+
     # Back up any existing hook that isn't already a symlink to ours
     if [[ -f "$hook_dst" && ! -L "$hook_dst" ]]; then
-        backup="$hook_dst.bak.$(date +%s)"
-        echo "  Backing up existing $hook_name → $hook_name.bak.$(date +%s)"
+        ts="$(date +%s)"
+        backup="$hook_dst.bak.$ts"
+        echo "  Backing up existing $hook_name → $hook_name.bak.$ts"
         mv "$hook_dst" "$backup"
     fi
 
@@ -52,7 +60,7 @@ for hook_src in "$HOOKS_SRC"/*; do
 done
 
 echo ""
-echo "Done. $INSTALLED hook(s) installed."
+echo "Done. $INSTALLED hook(s) installed, $SKIPPED already up-to-date."
 echo ""
 echo "Hooks installed:"
 echo "  pre-push  — runs 'tests/local_pre_pr_check.sh changed' before every push"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# scripts/setup-hooks.sh
+#
+# Installs the repository's git hooks from .githooks/ into .git/hooks/.
+# Run once after cloning, or re-run after hook updates.
+#
+# Usage:
+#   bash scripts/setup-hooks.sh
+#
+# What it installs:
+#   .githooks/pre-push  →  .git/hooks/pre-push
+#     Runs `tests/local_pre_pr_check.sh changed` before every push to a
+#     non-main branch, mirroring CI checks locally.
+#
+# To uninstall / disable a hook:
+#   rm .git/hooks/pre-push
+#
+# To bypass one push without uninstalling:
+#   git push --no-verify
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS_SRC="$REPO_ROOT/.githooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+if [[ ! -d "$HOOKS_DST" ]]; then
+    echo "ERROR: .git/hooks directory not found. Are you in the repo root?"
+    exit 1
+fi
+
+echo "Installing git hooks from .githooks/ → .git/hooks/ ..."
+
+INSTALLED=0
+SKIPPED=0
+
+for hook_src in "$HOOKS_SRC"/*; do
+    hook_name="$(basename "$hook_src")"
+    hook_dst="$HOOKS_DST/$hook_name"
+
+    # Back up any existing hook that isn't already a symlink to ours
+    if [[ -f "$hook_dst" && ! -L "$hook_dst" ]]; then
+        backup="$hook_dst.bak.$(date +%s)"
+        echo "  Backing up existing $hook_name → $hook_name.bak.$(date +%s)"
+        mv "$hook_dst" "$backup"
+    fi
+
+    cp "$hook_src" "$hook_dst"
+    chmod +x "$hook_dst"
+    echo "  Installed: $hook_name"
+    ((INSTALLED++)) || true
+done
+
+echo ""
+echo "Done. $INSTALLED hook(s) installed."
+echo ""
+echo "Hooks installed:"
+echo "  pre-push  — runs 'tests/local_pre_pr_check.sh changed' before every push"
+echo "              (skips pushes to main; bypass any push with: git push --no-verify)"
+echo ""
+echo "To verify:"
+echo "  cat .git/hooks/pre-push"

--- a/tests/feature_test_matrix.yaml
+++ b/tests/feature_test_matrix.yaml
@@ -516,3 +516,12 @@ lanes:
       - file: backend/tests/test_api_integration_pipeline.py
         domain: infra
         status: active
+
+  shell:
+    description: Shell script unit tests (bash-based)
+    runner: bash tests/test_setup_hooks.sh
+    files:
+      - file: tests/test_setup_hooks.sh
+        domain: dev-tooling
+        status: active
+        notes: Tests scripts/setup-hooks.sh and .githooks/pre-push (#373)

--- a/tests/test_setup_hooks.sh
+++ b/tests/test_setup_hooks.sh
@@ -24,7 +24,11 @@ echo ""
 # ── Setup: work in a temp dir with a fake .git/hooks ─────────────────────────
 TMPDIR_ROOT="$(mktemp -d)"
 FAKE_REPO="$TMPDIR_ROOT/repo"
-mkdir -p "$FAKE_REPO/.git/hooks"
+mkdir -p "$FAKE_REPO"
+
+# Initialize a real git repo so `git rev-parse --show-toplevel` works in hook
+git -C "$FAKE_REPO" init --quiet
+
 mkdir -p "$FAKE_REPO/.githooks"
 mkdir -p "$FAKE_REPO/scripts"
 mkdir -p "$FAKE_REPO/tests"
@@ -69,9 +73,15 @@ else
 fi
 
 # ── Test 4: re-running setup-hooks.sh succeeds (idempotent) ──────────────────
-echo "4. setup-hooks.sh is idempotent (re-run succeeds)"
+echo "4. setup-hooks.sh is idempotent (re-run succeeds and creates no extra backups)"
+BACKUPS_BEFORE=$(ls "$FAKE_REPO/.git/hooks/" | grep -c "pre-push.bak" || true)
 if (cd "$FAKE_REPO" && bash scripts/setup-hooks.sh >/dev/null 2>&1); then
-    ok "second run exits 0"
+    BACKUPS_AFTER=$(ls "$FAKE_REPO/.git/hooks/" | grep -c "pre-push.bak" || true)
+    if [[ $BACKUPS_AFTER -eq $BACKUPS_BEFORE ]]; then
+        ok "second run exits 0 and created no extra backups"
+    else
+        fail "second run created extra backups (before=$BACKUPS_BEFORE after=$BACKUPS_AFTER)"
+    fi
 else
     fail "second run failed"
 fi
@@ -110,10 +120,14 @@ echo "7. pre-push hook passes when local_pre_pr_check.sh exits 0"
 HOOK="$FAKE_REPO/.git/hooks/pre-push"
 # Simulate git calling the hook: local_ref local_sha remote_ref remote_sha
 PUSH_LINE="refs/heads/feat/foo abc123 refs/heads/feat/foo 000000"
-if echo "$PUSH_LINE" | (cd "$FAKE_REPO" && bash "$HOOK" origin https://example.com 2>&1) >/dev/null 2>&1; then
-    ok "hook exits 0 when gate passes"
+HOOK_OUT=$(echo "$PUSH_LINE" | (cd "$FAKE_REPO" && bash "$HOOK" origin https://example.com 2>&1)) && HOOK_EXIT=0 || HOOK_EXIT=$?
+
+if [[ $HOOK_EXIT -ne 0 ]]; then
+    fail "hook unexpectedly failed (exit $HOOK_EXIT)"
+elif echo "$HOOK_OUT" | grep -q "\[gate\]"; then
+    ok "hook exits 0 when gate passes (gate was executed)"
 else
-    fail "hook unexpectedly failed"
+    fail "hook exited 0 but gate stub output not found — gate may not have been called"
 fi
 
 # ── Test 8: pre-push hook skips when pushing a deletion (zero sha) ───────────

--- a/tests/test_setup_hooks.sh
+++ b/tests/test_setup_hooks.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# tests/test_setup_hooks.sh
+#
+# Tests for scripts/setup-hooks.sh
+# Run from repo root: bash tests/test_setup_hooks.sh
+# Exit 0 = all pass, Exit 1 = failures.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SETUP_HOOKS="$REPO_ROOT/scripts/setup-hooks.sh"
+GITHOOKS_SRC="$REPO_ROOT/.githooks"
+
+PASS=0
+FAIL=0
+
+ok()   { echo "  [PASS] $*"; ((PASS++)) || true; }
+fail() { echo "  [FAIL] $*"; ((FAIL++)) || true; }
+
+echo ""
+echo "=== tests/test_setup_hooks.sh ==="
+echo ""
+
+# ── Setup: work in a temp dir with a fake .git/hooks ─────────────────────────
+TMPDIR_ROOT="$(mktemp -d)"
+FAKE_REPO="$TMPDIR_ROOT/repo"
+mkdir -p "$FAKE_REPO/.git/hooks"
+mkdir -p "$FAKE_REPO/.githooks"
+mkdir -p "$FAKE_REPO/scripts"
+mkdir -p "$FAKE_REPO/tests"
+
+# Copy the real scripts into the fake repo
+cp "$SETUP_HOOKS"                     "$FAKE_REPO/scripts/setup-hooks.sh"
+cp "$GITHOOKS_SRC/pre-push"           "$FAKE_REPO/.githooks/pre-push"
+
+# Minimal gate script so the pre-push hook has something to call
+cat > "$FAKE_REPO/tests/local_pre_pr_check.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "[gate] mode=${1:-changed} — stub pass"
+exit 0
+EOF
+chmod +x "$FAKE_REPO/tests/local_pre_pr_check.sh"
+
+cleanup() { rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+
+# ── Test 1: setup-hooks.sh exits 0 ───────────────────────────────────────────
+echo "1. setup-hooks.sh exits 0 in a valid repo"
+if (cd "$FAKE_REPO" && bash scripts/setup-hooks.sh >/dev/null 2>&1); then
+    ok "exits 0"
+else
+    fail "non-zero exit code"
+fi
+
+# ── Test 2: pre-push hook file is installed ────────────────────────────────────
+echo "2. pre-push hook is installed to .git/hooks/"
+if [[ -f "$FAKE_REPO/.git/hooks/pre-push" ]]; then
+    ok "file exists"
+else
+    fail "file missing"
+fi
+
+# ── Test 3: installed hook is executable ─────────────────────────────────────
+echo "3. installed hook is executable"
+if [[ -x "$FAKE_REPO/.git/hooks/pre-push" ]]; then
+    ok "executable"
+else
+    fail "not executable"
+fi
+
+# ── Test 4: re-running setup-hooks.sh succeeds (idempotent) ──────────────────
+echo "4. setup-hooks.sh is idempotent (re-run succeeds)"
+if (cd "$FAKE_REPO" && bash scripts/setup-hooks.sh >/dev/null 2>&1); then
+    ok "second run exits 0"
+else
+    fail "second run failed"
+fi
+
+# ── Test 5: existing hook is backed up before overwrite ──────────────────────
+echo "5. existing .git/hooks/pre-push is backed up when not managed by us"
+# Remove the managed copy and place a foreign hook
+rm "$FAKE_REPO/.git/hooks/pre-push"
+echo "#!/bin/sh\necho old-hook" > "$FAKE_REPO/.git/hooks/pre-push"
+chmod +x "$FAKE_REPO/.git/hooks/pre-push"
+
+(cd "$FAKE_REPO" && bash scripts/setup-hooks.sh >/dev/null 2>&1)
+
+BACKUPS=$(ls "$FAKE_REPO/.git/hooks/" | grep -c "pre-push.bak" || true)
+if [[ $BACKUPS -ge 1 ]]; then
+    ok "backup created ($BACKUPS file(s))"
+else
+    fail "no backup created"
+fi
+
+# ── Test 6: fails gracefully when .git/hooks dir is absent ───────────────────
+echo "6. fails gracefully when .git directory is missing"
+FAKE_NO_GIT="$TMPDIR_ROOT/no-git"
+mkdir -p "$FAKE_NO_GIT/scripts" "$FAKE_NO_GIT/.githooks"
+cp "$SETUP_HOOKS"             "$FAKE_NO_GIT/scripts/setup-hooks.sh"
+cp "$GITHOOKS_SRC/pre-push"   "$FAKE_NO_GIT/.githooks/pre-push"
+
+if ! (cd "$FAKE_NO_GIT" && bash scripts/setup-hooks.sh >/dev/null 2>&1); then
+    ok "exits non-zero without .git/hooks"
+else
+    fail "should have failed without .git/hooks"
+fi
+
+# ── Test 7: pre-push hook passes when gate exits 0 ───────────────────────────
+echo "7. pre-push hook passes when local_pre_pr_check.sh exits 0"
+HOOK="$FAKE_REPO/.git/hooks/pre-push"
+# Simulate git calling the hook: local_ref local_sha remote_ref remote_sha
+PUSH_LINE="refs/heads/feat/foo abc123 refs/heads/feat/foo 000000"
+if echo "$PUSH_LINE" | (cd "$FAKE_REPO" && bash "$HOOK" origin https://example.com 2>&1) >/dev/null 2>&1; then
+    ok "hook exits 0 when gate passes"
+else
+    fail "hook unexpectedly failed"
+fi
+
+# ── Test 8: pre-push hook skips when pushing a deletion (zero sha) ───────────
+echo "8. pre-push hook skips branch deletion (zero sha)"
+DELETE_LINE="refs/heads/feat/old 0000000000000000000000000000000000000000 refs/heads/feat/old 0000000000000000000000000000000000000000"
+if echo "$DELETE_LINE" | (cd "$FAKE_REPO" && bash "$HOOK" origin https://example.com 2>&1) >/dev/null 2>&1; then
+    ok "hook exits 0 on branch deletion"
+else
+    fail "hook failed on branch deletion"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "=== $PASS passed | $FAIL failed ==="
+echo ""
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Phase 2 of testing epic #370 — standardize pre-push local validation so failures are caught locally before CI.

## Changes

### `.githooks/pre-push`
Git hook that runs `tests/local_pre_pr_check.sh changed` automatically before every `git push` to a non-`main` branch.
- Skips branch deletions (zero sha)
- Skips direct pushes to `main`
- Bypassable with `git push --no-verify`

### `scripts/setup-hooks.sh`
One-time installer that copies `.githooks/` hooks into `.git/hooks/`.
- Backs up any pre-existing foreign hooks (`.bak.<epoch>`)
- Idempotent — safe to re-run after hook updates
- Usage: `bash scripts/setup-hooks.sh`

### `tests/test_setup_hooks.sh`
8 bash unit tests:
1. `setup-hooks.sh` exits 0 in a valid repo
2. `pre-push` file is installed to `.git/hooks/`
3. Installed hook is executable
4. Idempotent (re-run succeeds)
5. Existing foreign hook is backed up
6. Fails gracefully when `.git/hooks/` is absent
7. Hook passes when gate exits 0
8. Hook skips branch deletions (zero sha)

All 8 pass.

### `CONTRIBUTING.md`
New **Local Pre-PR Gate** section (before Current Action Items):
- Quick-start commands for `changed`, `full`, `full --with-e2e`
- Hook install instructions and bypass notes
- When-to-use matrix (normal vs risky vs release)
- Environment override docs (`SKIP_BACKEND`, `SKIP_FRONTEND`, `SKIP_ETL`)

Item 1 in Current Action Items updated to lead with the pre-PR gate.

### `tests/feature_test_matrix.yaml`
New `shell` lane added for bash script tests.

## Acceptance Criteria
- [x] `bash scripts/setup-hooks.sh` installs hook in one command
- [x] Hook runs `changed` mode automatically on push
- [x] Hook is bypassable with `--no-verify`
- [x] 8 tests validate all key behaviours
- [x] CONTRIBUTING.md documents both manual and automatic workflows

Closes #373
Part of epic #370