### PR TITLE
fix: complete Locker Room standardization and validation UX (#90)

### DIFF
--- a/frontend/src/pages/team-owner/YourLockerRoom.jsx
+++ b/frontend/src/pages/team-owner/YourLockerRoom.jsx
@@ -5,14 +5,12 @@ import {
   FiRepeat,
   FiPlus,
   FiList,
-  FiSend,
   FiX,
   FiBarChart2,
 } from 'react-icons/fi';
 import { Link } from 'react-router-dom';
 // --- Commissioner Modal Imports ---
 import ScoringRulesModal from '../commissioner/components/ScoringRulesModal';
-import OwnerManagementModal from '../commissioner/components/OwnerManagementModal';
 import WaiverWireRulesModal from '../commissioner/components/WaiverWireRulesModal';
 import TradeRulesModal from '../commissioner/components/TradeRulesModal';
 import PlayerIdentityCard from '../../components/player/PlayerIdentityCard';
@@ -318,7 +316,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
   const viewedOwnerId = activeOwnerId ? Number(activeOwnerId) : null;
   // --- 0.1 Commissioner Modal State ---
   const [showScoring, setShowScoring] = useState(false);
-  const [showOwners, setShowOwners] = useState(false);
   const [showWaivers, setShowWaivers] = useState(false);
   const [showTrades, setShowTrades] = useState(false);
   const [showRuleViewer, setShowRuleViewer] = useState(false);
@@ -1234,10 +1231,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
         open={showScoring}
         onClose={() => setShowScoring(false)}
       />
-      <OwnerManagementModal
-        open={showOwners}
-        onClose={() => setShowOwners(false)}
-      />
       <WaiverWireRulesModal
         open={showWaivers}
         onClose={() => setShowWaivers(false)}
@@ -1325,8 +1318,8 @@ export default function YourLockerRoom({ activeOwnerId }) {
       )}
 
       <div className="mb-6">
-        <div className="mt-6 flex flex-wrap items-center gap-2 lg:flex-nowrap lg:gap-2 lg:overflow-x-auto">
-          <div className="contents">
+        <div className="mt-6 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
             <button
               onClick={() =>
                 userInfo.is_commissioner
@@ -1337,14 +1330,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
             >
               Scoring Rules
             </button>
-            {userInfo.is_commissioner && (
-              <button
-                onClick={() => setShowOwners(true)}
-                className={`${controlButtonClass} ${buttonSecondary}`}
-              >
-                Owner Management
-              </button>
-            )}
             <button
               onClick={() =>
                 userInfo.is_commissioner
@@ -1380,6 +1365,9 @@ export default function YourLockerRoom({ activeOwnerId }) {
                 Keeper Rules
               </button>
             )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
             <Link
               to="/waivers"
               className={`${controlButtonClass} ${buttonPrimary} inline-flex items-center justify-center gap-2`}
@@ -1392,25 +1380,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
             >
               <FiRepeat className="text-base" /> Manage Keepers
             </Link>
-
-            {canProposeTrade && (
-              <button
-                onClick={() => setShowProposeTrade(true)}
-                className={`${controlButtonClass} ${buttonPrimary}`}
-              >
-                <div className="flex items-center justify-center gap-2 whitespace-nowrap">
-                  <FiSend className="text-base" /> Propose Trade
-                </div>
-              </button>
-            )}
-
-            <div
-              className={`${controlButtonClass} inline-flex items-center gap-2 border border-slate-300 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200`}
-            >
-              <FiRepeat className="text-base text-blue-400" />
-              <span className="uppercase">Pending Trades</span>
-              <span className="font-black">{summary.pending_trades}</span>
-            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/team-owner/YourLockerRoom.jsx
+++ b/frontend/src/pages/team-owner/YourLockerRoom.jsx
@@ -320,17 +320,8 @@ export default function YourLockerRoom({ activeOwnerId }) {
   const [showTrades, setShowTrades] = useState(false);
   const [showRuleViewer, setShowRuleViewer] = useState(false);
   const [ruleViewerType, setRuleViewerType] = useState('scoring');
-  const [showProposeTrade, setShowProposeTrade] = useState(false);
   const [leagueOwners, setLeagueOwners] = useState([]);
   const [currentUserId, setCurrentUserId] = useState(null);
-  const [myTradeRoster, setMyTradeRoster] = useState([]);
-  const [targetRoster, setTargetRoster] = useState([]);
-  const [proposalToUserId, setProposalToUserId] = useState('');
-  const [offeredPlayerIds, setOfferedPlayerIds] = useState([]);
-  const [requestedPlayerIds, setRequestedPlayerIds] = useState([]);
-  const [proposalNote, setProposalNote] = useState('');
-  const [offeredDollars, setOfferedDollars] = useState('');
-  const [requestedDollars, setRequestedDollars] = useState('');
   const [toast, setToast] = useState(null);
   const [showPlayerPerformance, setShowPlayerPerformance] = useState(false);
   const [showLineupValidationModal, setShowLineupValidationModal] =
@@ -479,20 +470,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
           setSummary(dashRes.data);
         }
 
-        if (!loggedInUserId) {
-          setMyTradeRoster([]);
-        } else {
-          try {
-            const myDashRes = await apiClient.get(
-              `/dashboard/${loggedInUserId}`
-            );
-            setMyTradeRoster(
-              Array.isArray(myDashRes.data?.roster) ? myDashRes.data.roster : []
-            );
-          } catch {
-            setMyTradeRoster([]);
-          }
-        }
       } catch {
         setCurrentUserId(null);
         setUserInfo({
@@ -508,7 +485,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
         setMaxPositionLimits(DEFAULT_MAX_POSITION_LIMITS);
         setAllowPartialLineup(false);
         setSummary(null);
-        setMyTradeRoster([]);
         setLeagueOwners([]);
       }
     }
@@ -540,26 +516,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
     };
   }, [loadLeagueSettings, userInfo.leagueId]);
 
-  useEffect(() => {
-    async function loadTargetRoster() {
-      if (!proposalToUserId) {
-        setTargetRoster([]);
-        setRequestedPlayerIds([]);
-        return;
-      }
-
-      try {
-        const res = await apiClient.get(`/dashboard/${proposalToUserId}`);
-        console.log('loaded target roster for', proposalToUserId, res.data);
-        setTargetRoster(Array.isArray(res.data?.roster) ? res.data.roster : []);
-      } catch (err) {
-        console.error('failed to load target roster', err);
-        setTargetRoster([]);
-      }
-    }
-
-    loadTargetRoster();
-  }, [proposalToUserId]);
   // --- 1.2 STATE MANAGEMENT ---
   const [teamData, setTeamData] = useState(null);
   const [rosterState, setRosterState] = useState([]);
@@ -592,8 +548,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
   const [startSitSort] = useState('position');
   // FIX: Start loading as true to avoid sync setState inside useEffect
   const [loading, setLoading] = useState(true);
-  const canProposeTrade =
-    !!currentUserId && (!viewedOwnerId || viewedOwnerId === currentUserId);
 
   // --- 1.3 DATA RETRIEVAL (The Engine) ---
   const fetchTeam = useCallback(() => {
@@ -1051,95 +1005,6 @@ export default function YourLockerRoom({ activeOwnerId }) {
     }
   };
 
-  const handleSubmitTradeProposal = async () => {
-    console.log('handleSubmitTradeProposal called', {
-      canProposeTrade,
-      proposalToUserId,
-      offeredPlayerIds,
-      requestedPlayerIds,
-      offeredDollars,
-      requestedDollars,
-    });
-    if (!canProposeTrade) {
-      setToast({
-        message: 'Trades can only be proposed from your own roster page.',
-        type: 'error',
-      });
-      return;
-    }
-
-    if (
-      !proposalToUserId ||
-      offeredPlayerIds.length === 0 ||
-      requestedPlayerIds.length === 0
-    ) {
-      setToast({ message: 'Select manager and at least one player on each side.', type: 'error' });
-      return;
-    }
-
-    try {
-      const assetsFromA = offeredPlayerIds.map((playerId) => ({
-        asset_type: 'PLAYER',
-        player_id: Number(playerId),
-      }));
-      const assetsFromB = requestedPlayerIds.map((playerId) => ({
-        asset_type: 'PLAYER',
-        player_id: Number(playerId),
-      }));
-
-      if ((Number(offeredDollars) || 0) > 0) {
-        assetsFromA.push({
-          asset_type: 'DRAFT_DOLLARS',
-          amount: Number(offeredDollars) || 0,
-        });
-      }
-      if ((Number(requestedDollars) || 0) > 0) {
-        assetsFromB.push({
-          asset_type: 'DRAFT_DOLLARS',
-          amount: Number(requestedDollars) || 0,
-        });
-      }
-
-      await apiClient.post(`/trades/leagues/${userInfo.leagueId}/submit-v2`, {
-        team_a_id: Number(currentUserId),
-        team_b_id: Number(proposalToUserId),
-        assets_from_a: assetsFromA,
-        assets_from_b: assetsFromB,
-        proposal_note: proposalNote,
-      });
-
-      setToast({ message: 'Trade proposal submitted.', type: 'success' });
-      setShowProposeTrade(false);
-      setProposalToUserId('');
-      setOfferedPlayerIds([]);
-      setRequestedPlayerIds([]);
-      setProposalNote('');
-      setOfferedDollars('');
-      setRequestedDollars('');
-      fetchTeam();
-    } catch (err) {
-      const detail = err.response?.data?.detail;
-      const flattenedDetail =
-        typeof detail === 'string'
-          ? detail
-          : Array.isArray(detail)
-            ? detail.join(', ')
-            : detail && typeof detail === 'object'
-              ? Object.entries(detail)
-                  .flatMap(([key, value]) => {
-                    if (Array.isArray(value)) {
-                      return value.map((message) => `${key}: ${message}`);
-                    }
-                    return [`${key}: ${String(value)}`];
-                  })
-                  .join(', ')
-              : null;
-      setToast({
-        message: flattenedDetail || 'Failed to submit trade proposal.',
-        type: 'error',
-      });
-    }
-  };
 
   const openPlayerPerformance = async (player) => {
     setSelectedPlayer(player);
@@ -1421,177 +1286,7 @@ export default function YourLockerRoom({ activeOwnerId }) {
         </div>
       </div>
 
-      {showProposeTrade && canProposeTrade && (
-        <div className={modalOverlay}>
-          <div className={`${modalSurface} max-w-2xl p-6`}>
-            <div className="mb-5 flex items-center justify-between">
-              <h3 className={modalTitle}>Propose Trade</h3>
-              <button
-                onClick={() => setShowProposeTrade(false)}
-                className={modalCloseButton}
-              >
-                <FiX />
-              </button>
-            </div>
 
-            <div className="space-y-4">
-              <div>
-                <label
-                  htmlFor="trade-with"
-                  className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400"
-                >
-                  Trade With
-                </label>
-                <select
-                  id="trade-with"
-                  value={proposalToUserId}
-                  onChange={(e) => setProposalToUserId(e.target.value)}
-                  className={inputBase}
-                >
-                  <option value="">Select manager</option>
-                  {leagueOwners
-                    .filter((owner) => owner.id !== currentUserId)
-                    .map((owner) => (
-                      <option key={owner.id} value={owner.id}>
-                        {owner.team_name || owner.username}
-                        {owner.division_name ? ` (${owner.division_name})` : ''}
-                      </option>
-                    ))}
-                </select>
-              </div>
-
-              <div>
-                <label
-                  htmlFor="you-offer"
-                  className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400"
-                >
-                  You Offer
-                </label>
-                <select
-                  id="you-offer"
-                  multiple
-                  size={6}
-                  value={offeredPlayerIds}
-                  onChange={(e) =>
-                    setOfferedPlayerIds(
-                      Array.from(e.target.selectedOptions, (opt) => opt.value)
-                    )
-                  }
-                  className={inputBase}
-                >
-                  {myTradeRoster.map((player) => (
-                    <option key={player.id} value={player.id}>
-                      {player.name} ({player.position})
-                    </option>
-                  ))}
-                </select>
-                <p className="mt-1 text-xs text-slate-500">
-                  Hold Ctrl (Windows) or Cmd (Mac) to select multiple players.
-                </p>
-              </div>
-
-              <div>
-                <label
-                  htmlFor="you-request"
-                  className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400"
-                >
-                  You Request
-                </label>
-                <select
-                  id="you-request"
-                  multiple
-                  size={6}
-                  value={requestedPlayerIds}
-                  onChange={(e) =>
-                    setRequestedPlayerIds(
-                      Array.from(e.target.selectedOptions, (opt) => opt.value)
-                    )
-                  }
-                  className={inputBase}
-                  disabled={!proposalToUserId}
-                >
-                  {targetRoster.map((player) => (
-                    <option key={player.id} value={player.id}>
-                      {player.name} ({player.position})
-                    </option>
-                  ))}
-                </select>
-                <p className="mt-1 text-xs text-slate-500">
-                  Hold Ctrl (Windows) or Cmd (Mac) to select multiple players.
-                </p>
-              </div>
-
-              <div className="flex gap-4">
-                <div className="flex-1">
-                  <label
-                    htmlFor="offered-dollars"
-                    className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400"
-                  >
-                    Offer $ (future draft)
-                  </label>
-                  <input
-                    id="offered-dollars"
-                    type="number"
-                    min="0"
-                    step="1"
-                    value={offeredDollars}
-                    onChange={(e) => setOfferedDollars(e.target.value)}
-                    className={inputBase}
-                    placeholder="0"
-                  />
-                </div>
-                <div className="flex-1">
-                  <label
-                    htmlFor="requested-dollars"
-                    className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400"
-                  >
-                    Request $ (future draft)
-                  </label>
-                  <input
-                    id="requested-dollars"
-                    type="number"
-                    min="0"
-                    step="1"
-                    value={requestedDollars}
-                    onChange={(e) => setRequestedDollars(e.target.value)}
-                    className={inputBase}
-                    placeholder="0"
-                    disabled={!proposalToUserId}
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label className="mb-1 block text-xs font-bold uppercase tracking-wider text-slate-400">
-                  Note (Optional)
-                </label>
-                <textarea
-                  rows={3}
-                  value={proposalNote}
-                  onChange={(e) => setProposalNote(e.target.value)}
-                  className={inputBase}
-                  placeholder="Add context for commissioner review"
-                />
-              </div>
-            </div>
-
-            <div className="mt-6 flex justify-end gap-3">
-              <button
-                onClick={() => setShowProposeTrade(false)}
-                className={buttonSecondary}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSubmitTradeProposal}
-                className={buttonPrimary}
-              >
-                Submit Proposal
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
       {showPlayerPerformance && (
         <div className={modalOverlay}>

--- a/frontend/tests/MyTeam.test.jsx
+++ b/frontend/tests/MyTeam.test.jsx
@@ -370,7 +370,9 @@ describe('MyTeam (Roster & Lineups)', () => {
     });
   });
 
-  test('displays pending trades stat box', async () => {
+  // pending_trades stat box was removed from Locker Room scope (issue #90).
+  // Verify standing badge still renders and Pending Trades is gone.
+  test('displays standing badge and omits removed pending-trades stat box', async () => {
     const mockSummary = {
       player_count: 15,
       active_lineups: 8,
@@ -418,8 +420,10 @@ describe('MyTeam (Roster & Lineups)', () => {
     render(<MyTeam activeOwnerId={1} />);
 
     await waitFor(() => {
-      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText(/#1 Place/i)).toBeInTheDocument();
     });
+    // pending trades UI was removed (issue #90)
+    expect(screen.queryByText(/Pending Trades/i)).toBeNull();
   });
 
   test('displays roster list from summary', async () => {
@@ -558,7 +562,8 @@ describe('MyTeam (Roster & Lineups)', () => {
     await waitFor(() => {
       expect(screen.getByText(/Scoring Rules/i)).toBeInTheDocument();
     });
-    expect(screen.getByText(/Owner Management/i)).toBeInTheDocument();
+    // Owner Management is no longer surfaced in Locker Room (issue #90)
+    expect(screen.queryByText(/Owner Management/i)).toBeNull();
     expect(screen.getByText(/Keeper Rules/i)).toBeInTheDocument();
   });
 
@@ -834,7 +839,8 @@ describe('MyTeam (Roster & Lineups)', () => {
     });
 
     render(<MyTeam activeOwnerId={1} />);
-    await waitFor(() => expect(screen.getByText(/RB1/i)).toBeInTheDocument());
+    // QB1 is non-taxi STARTER and QB slot is configured, so it renders in the active section
+    await waitFor(() => expect(screen.getByText(/QB1/i)).toBeInTheDocument());
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     // wait for the submit button to appear and be enabled (no validation errors)
     let button;
@@ -1138,110 +1144,36 @@ describe('MyTeam (Roster & Lineups)', () => {
     });
   });
 
-  test('trade modal shows dollar inputs and sends them', async () => {
+  // Trade proposal was removed from Locker Room scope (issue #90).
+  // Trade functionality now lives in the dedicated Trades module.
+  test('Propose Trade button is not present in Locker Room (issue #90)', async () => {
     apiClient.get.mockImplementation((url) => {
       if (url === '/auth/me')
         return Promise.resolve({
-          data: {
-            user_id: 1,
-            username: 'alice',
-            league_id: 1,
-            is_commissioner: false,
-          },
+          data: { user_id: 1, username: 'alice', league_id: 1, is_commissioner: false },
         });
       if (url === '/leagues/1')
         return Promise.resolve({ data: { name: 'The Big Show' } });
       if (url === '/leagues/1/settings')
-        return Promise.resolve({
-          data: {
-            scoring_rules: [],
-            waiver_deadline: null,
-            trade_deadline: null,
-          },
-        });
+        return Promise.resolve({ data: { scoring_rules: [] } });
       if (url === '/dashboard/1')
-        return Promise.resolve({
-          data: { roster: [{ id: 201, name: 'P1', position: 'WR' }] },
-        });
-      if (url === '/dashboard/2')
-        return Promise.resolve({
-          data: { roster: [{ id: 301, name: 'Other', position: 'RB' }] },
-        });
-      if (url === '/leagues/owners?league_id=1')
-        return Promise.resolve({
-          data: [{ id: 2, username: 'bob', team_name: 'Bob Team' }],
-        });
+        return Promise.resolve({ data: { roster: [] } });
       if (url.startsWith('/team/1?week='))
         return Promise.resolve({ data: { roster: [] } });
       if (url === '/scoring/1') return Promise.resolve({ data: [] });
       return Promise.reject(new Error('Unknown URL'));
     });
-
     apiClient.post.mockResolvedValue({ data: {} });
-    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     render(<MyTeam activeOwnerId={1} />);
-    await waitFor(() =>
-      expect(screen.getByText(/Propose Trade/i)).toBeInTheDocument()
-    );
-    fireEvent.click(screen.getByRole('button', { name: /Propose Trade/i }));
-    expect(
-      screen.getByLabelText(/Offer \$ \(future draft\)/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText(/Request \$ \(future draft\)/i)
-    ).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText(/Trade With/i), {
-      target: { value: '2' },
-    });
-    // wait for target roster options to load, then pick the first one.
-    await waitFor(() => {
-      const reqSel = screen.getByLabelText(/You Request/i);
-      expect(reqSel.children.length).toBeGreaterThan(0);
-    });
-    const reqSelect = screen.getByLabelText(/You Request/i);
-    const optionValue = reqSelect.children[0].value;
-    fireEvent.change(reqSelect, { target: { value: optionValue } });
 
-    fireEvent.change(screen.getByLabelText(/You Offer/i), {
-      target: { value: '201' },
-    });
-    fireEvent.change(screen.getByLabelText(/Offer \$ \(future draft\)/i), {
-      target: { value: '5' },
-    });
-    fireEvent.change(screen.getByLabelText(/Request \$ \(future draft\)/i), {
-      target: { value: '3' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /Submit Proposal/i }));
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'handleSubmitTradeProposal called',
-        expect.objectContaining({
-          canProposeTrade: true,
-          proposalToUserId: '2',
-          offeredPlayerIds: ['201'],
-          requestedPlayerIds: [optionValue],
-          offeredDollars: '5',
-          requestedDollars: '3',
-        })
-      );
-      expect(apiClient.post).toHaveBeenCalledWith(
-        '/trades/leagues/1/submit-v2',
-        expect.objectContaining({
-          team_a_id: 1,
-          team_b_id: 2,
-          assets_from_a: expect.arrayContaining([
-            expect.objectContaining({ asset_type: 'PLAYER', player_id: 201 }),
-            expect.objectContaining({ asset_type: 'DRAFT_DOLLARS', amount: 5 }),
-          ]),
-          assets_from_b: expect.arrayContaining([
-            expect.objectContaining({ asset_type: 'PLAYER', player_id: Number(optionValue) }),
-            expect.objectContaining({ asset_type: 'DRAFT_DOLLARS', amount: 3 }),
-          ]),
-        })
-      );
+      // Page loaded (scoring rules button visible)
+      expect(screen.getByText(/Scoring Rules/i)).toBeInTheDocument();
     });
-    consoleSpy.mockRestore();
+
+    expect(screen.queryByRole('button', { name: /Propose Trade/i })).toBeNull();
+    expect(screen.queryByText(/Pending Trades/i)).toBeNull();
   });
 
   test('handles API errors gracefully', async () => {

--- a/frontend/tests/YourLockerRoom.test.jsx
+++ b/frontend/tests/YourLockerRoom.test.jsx
@@ -159,6 +159,18 @@ describe('YourLockerRoom — Start/Sit Sorter (issue #173)', () => {
     expect(screen.queryByRole('button', { name: /Owner Management/i })).toBeNull();
   });
 
+  test('lineup view omits unrelated trade controls in top actions', async () => {
+    setupMocks();
+    render(<YourLockerRoom activeOwnerId={1} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/QB One/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /Propose Trade/i })).toBeNull();
+    expect(screen.queryByText(/Pending Trades/i)).toBeNull();
+  });
+
   test('disables QB starter slot when league config turns QB off', async () => {
     apiClient.get.mockImplementation((url) => {
       if (url === '/auth/me') {
@@ -177,6 +189,7 @@ describe('YourLockerRoom — Start/Sit Sorter (issue #173)', () => {
           data: {
             starting_slots: {
               ACTIVE_ROSTER_SIZE: 1,
+              ALLOW_PARTIAL_LINEUP: 1,
               QB: 0,
               MAX_QB: 0,
               RB: 1,
@@ -230,6 +243,116 @@ describe('YourLockerRoom — Start/Sit Sorter (issue #173)', () => {
     await waitFor(() => {
       expect(screen.queryByText(/QB 0/)).toBeNull();
       expect(screen.getByText(/RB 1/)).toBeInTheDocument();
+    });
+  });
+
+  test('Owner Management button is removed for commissioners too', async () => {
+    apiClient.get.mockImplementation((url) => {
+      if (url === '/auth/me') {
+        return Promise.resolve({
+          data: { user_id: 1, username: 'alice', league_id: 1, is_commissioner: true },
+        });
+      }
+      if (url === '/leagues/1') {
+        return Promise.resolve({ data: { name: 'Commissioner League', draft_status: 'COMPLETED' } });
+      }
+      if (url.startsWith('/leagues/owners')) {
+        return Promise.resolve({ data: [] });
+      }
+      if (url.startsWith('/leagues/1/settings')) {
+        return Promise.resolve({ data: { starting_slots: {}, scoring_rules: [] } });
+      }
+      if (url.startsWith('/dashboard/')) {
+        return Promise.resolve({ data: { roster: testRoster } });
+      }
+      if (url.startsWith('/team/1?week=')) {
+        return Promise.resolve({ data: { roster: testRoster } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    apiClient.post.mockResolvedValue({ data: {} });
+
+    render(<YourLockerRoom activeOwnerId={1} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/QB One/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /Owner Management/i })).toBeNull();
+  });
+
+  test('loads selected future week roster context', async () => {
+    apiClient.get.mockImplementation((url) => {
+      if (url === '/auth/me') {
+        return Promise.resolve({
+          data: { user_id: 1, username: 'alice', league_id: 1, is_commissioner: false },
+        });
+      }
+      if (url === '/leagues/1') {
+        return Promise.resolve({ data: { name: 'Future Week League', draft_status: 'COMPLETED' } });
+      }
+      if (url.startsWith('/leagues/owners')) {
+        return Promise.resolve({ data: [] });
+      }
+      if (url.startsWith('/leagues/1/settings')) {
+        return Promise.resolve({
+          data: {
+            starting_slots: {
+              ACTIVE_ROSTER_SIZE: 1,
+              QB: 0,
+              MAX_QB: 0,
+              RB: 1,
+              MAX_RB: 1,
+              WR: 0,
+              MAX_WR: 0,
+              TE: 0,
+              MAX_TE: 0,
+              K: 0,
+              MAX_K: 0,
+              DEF: 0,
+              MAX_DEF: 0,
+              FLEX: 0,
+              MAX_FLEX: 0,
+            },
+            scoring_rules: [],
+          },
+        });
+      }
+      if (url.startsWith('/dashboard/')) {
+        return Promise.resolve({
+          data: {
+            roster: [
+              { id: 2, player_id: 2, name: 'RB One', position: 'RB', nfl_team: 'DAL', status: 'STARTER' },
+            ],
+          },
+        });
+      }
+      if (url.startsWith('/team/1?week=')) {
+        return Promise.resolve({
+          data: {
+            roster: [
+              { id: 2, player_id: 2, name: 'RB One', position: 'RB', nfl_team: 'DAL', status: 'STARTER' },
+            ],
+            lineup_submitted: false,
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    apiClient.post.mockResolvedValue({ data: {} });
+
+    render(<YourLockerRoom activeOwnerId={1} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/RB One/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Week/i), { target: { value: '3' } });
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith('/team/1?week=3');
     });
   });
 });

--- a/frontend/tests/YourLockerRoom.test.jsx
+++ b/frontend/tests/YourLockerRoom.test.jsx
@@ -247,6 +247,7 @@ describe('YourLockerRoom — Start/Sit Sorter (issue #173)', () => {
   });
 
   test('Owner Management button is removed for commissioners too', async () => {
+    setupMocks();
     apiClient.get.mockImplementation((url) => {
       if (url === '/auth/me') {
         return Promise.resolve({
@@ -254,7 +255,7 @@ describe('YourLockerRoom — Start/Sit Sorter (issue #173)', () => {
         });
       }
       if (url === '/leagues/1') {
-        return Promise.resolve({ data: { name: 'Commissioner League', draft_status: 'COMPLETED' } });
+        return Promise.resolve({ data: { name: 'Test League', draft_status: 'COMPLETED' } });
       }
       if (url.startsWith('/leagues/owners')) {
         return Promise.resolve({ data: [] });
@@ -283,6 +284,10 @@ describe('YourLockerRoom — Start/Sit Sorter (issue #173)', () => {
   });
 
   test('loads selected future week roster context', async () => {
+    const week3Roster = [
+      { id: 20, player_id: 20, name: 'RB Week Three', position: 'RB', nfl_team: 'NYG', status: 'STARTER' },
+    ];
+    setupMocks();
     apiClient.get.mockImplementation((url) => {
       if (url === '/auth/me') {
         return Promise.resolve({
@@ -290,69 +295,41 @@ describe('YourLockerRoom — Start/Sit Sorter (issue #173)', () => {
         });
       }
       if (url === '/leagues/1') {
-        return Promise.resolve({ data: { name: 'Future Week League', draft_status: 'COMPLETED' } });
+        return Promise.resolve({ data: { name: 'Test League', draft_status: 'COMPLETED' } });
       }
       if (url.startsWith('/leagues/owners')) {
         return Promise.resolve({ data: [] });
       }
       if (url.startsWith('/leagues/1/settings')) {
-        return Promise.resolve({
-          data: {
-            starting_slots: {
-              ACTIVE_ROSTER_SIZE: 1,
-              QB: 0,
-              MAX_QB: 0,
-              RB: 1,
-              MAX_RB: 1,
-              WR: 0,
-              MAX_WR: 0,
-              TE: 0,
-              MAX_TE: 0,
-              K: 0,
-              MAX_K: 0,
-              DEF: 0,
-              MAX_DEF: 0,
-              FLEX: 0,
-              MAX_FLEX: 0,
-            },
-            scoring_rules: [],
-          },
-        });
+        return Promise.resolve({ data: { starting_slots: {}, scoring_rules: [] } });
       }
       if (url.startsWith('/dashboard/')) {
-        return Promise.resolve({
-          data: {
-            roster: [
-              { id: 2, player_id: 2, name: 'RB One', position: 'RB', nfl_team: 'DAL', status: 'STARTER' },
-            ],
-          },
-        });
+        return Promise.resolve({ data: { roster: testRoster } });
+      }
+      if (url === '/team/1?week=3') {
+        return Promise.resolve({ data: { roster: week3Roster, lineup_submitted: false } });
       }
       if (url.startsWith('/team/1?week=')) {
-        return Promise.resolve({
-          data: {
-            roster: [
-              { id: 2, player_id: 2, name: 'RB One', position: 'RB', nfl_team: 'DAL', status: 'STARTER' },
-            ],
-            lineup_submitted: false,
-          },
-        });
+        return Promise.resolve({ data: { roster: testRoster } });
       }
       return Promise.resolve({ data: {} });
     });
-
     apiClient.post.mockResolvedValue({ data: {} });
 
     render(<YourLockerRoom activeOwnerId={1} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/RB One/i)).toBeInTheDocument();
+      expect(screen.getByText(/QB One/i)).toBeInTheDocument();
     });
 
     fireEvent.change(screen.getByLabelText(/Week/i), { target: { value: '3' } });
 
     await waitFor(() => {
       expect(apiClient.get).toHaveBeenCalledWith('/team/1?week=3');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/RB Week Three/i)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR completes a strict closure pass for Issue #90 by tightening Locker Room to lineup-builder scope and enforcing role-safe controls.

### Delivered
- Removed Owner Management from Locker Room for all roles.
- Reorganized top controls into clean rule/action rows.
- Removed unrelated trade controls from Locker Room top actions (Propose Trade, Pending Trades).
- Preserved recommended lineup and validation surfaces.
- Added regression tests for:
  - Owner Management absent for commissioners and non-commissioners
  - Top actions exclude unrelated trade controls
  - Future-week selection loads week-specific roster context

## Closes
Closes #90

## Testing
- [x] 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/ppl_insight_hub/fantasy-football-pi/fantasy-football-pi/frontend[39m

 [32m✓[39m tests/YourLockerRoom.test.jsx [2m([22m[2m8 tests[22m[2m)[22m[33m 3758[2mms[22m[39m
     [33m[2m✓[22m[39m Recommended Sits section shows bench players (not empty) [33m 1250[2mms[22m[39m
     [33m[2m✓[22m[39m Apply to My Lineup button appears in Recommended mode [33m 593[2mms[22m[39m
     [33m[2m✓[22m[39m Apply to My Lineup switches back to Actual view and shows toast [33m 579[2mms[22m[39m
     [33m[2m✓[22m[39m Owner Management button is hidden for non-commissioners [33m 377[2mms[22m[39m
     [33m[2m✓[22m[39m lineup view omits unrelated trade controls in top actions [33m 402[2mms[22m[39m
     [33m[2m✓[22m[39m Owner Management button is removed for commissioners too [33m 348[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m8 passed[39m[22m[90m (8)[39m
[2m   Start at [22m 13:15:35
[2m   Duration [22m 7.65s[2m (transform 789ms, setup 723ms, import 694ms, tests 3.76s, environment 1.87s)[22m

## Acceptance Mapping
- [x] Rule buttons use standard styling
- [x] Rule buttons open read-only views for non-commissioners
- [x] Owner Management removed from this page
- [x] Top controls reorganized cleanly
- [x] Lineup validation green/red overall + position-group remains present
- [x] Future-week week-selection context supported
- [x] Disabled positions do not appear in lineup slots
- [x] Non-applicable controls removed from top action row
- [x] Recommended lineup section preserved
