### PR TITLE
feat(#103): Phase 2 — Position registry, canonical snapshot table, alias map, and stale-player deactivation

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1027,3 +1027,98 @@ class MflIngestionFile(Base):
     retention_class = Column(String(32), nullable=True)
     archived_path = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+# --- ISSUE #103 PHASE 2: Position registry ---
+class Position(Base):
+    """Canonical position registry for all fantasy-eligible NFL positions.
+
+    Replaces the free-form VARCHAR strings in Player.position and
+    PlayerSeason.position with FK-backed references, enabling consistent
+    ML feature engineering and draft logic.
+
+    Columns
+    -------
+    abbreviation : str(8)
+        Short token used throughout the app (QB, RB, WR, TE, K, DEF, FLEX).
+    label : str(64)
+        Human-readable display name ("Quarterback", "Running Back", …).
+    is_active : bool
+        False for deprecated/legacy positions (e.g. "TD", "PK").
+    source : str(32)
+        Origin of the record: "canonical" (hand-authored) or "mfl" (imported).
+    sort_order : int
+        Preferred display order in lineup builders and tables.
+    """
+
+    __tablename__ = "positions"
+    __table_args__ = (
+        UniqueConstraint("abbreviation", name="uq_positions_abbreviation"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    abbreviation = Column(String(8), nullable=False, index=True)
+    label = Column(String(64), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    source = Column(String(32), nullable=False, default="canonical")
+    sort_order = Column(Integer, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+# --- ISSUE #103 PHASE 2: Versioned canonicalization snapshot ---
+class CanonicalPlayerSnapshot(Base):
+    """Versioned record of each canonicalization run result.
+
+    Each time the ETL pipeline runs ``canonicalize_player_metadata()`` it
+    produces a SHA-256 content digest over the (player_id, canonical_name,
+    canonical_position) triples.  Persisting that digest here allows:
+      - Change detection (only re-process when digest differs)
+      - Rollback: compare current state to any prior snapshot
+      - Shadow comparison: side-by-side diff between run versions
+
+    Columns
+    -------
+    season : int
+        The roster season this snapshot covers.
+    content_digest : str(64)
+        SHA-256 hex digest of the sorted canonical (player_id, name, position)
+        payload, identical to the value computed by
+        ``canonicalize_player_metadata()``.
+    total_rows : int
+        Raw row count before deduplication.
+    unique_player_ids : int
+        Count of distinct player IDs in this snapshot.
+    deduplicated_rows : int
+        Rows removed during deduplication (``total_rows - unique_player_ids``).
+    duplicate_name_keys : JSON
+        List of {canonical_name_key, player_count} dicts for names mapping to
+        multiple player IDs.
+    position_distribution : JSON
+        Mapping of canonical position → row count for quick QA.
+    source : str(32)
+        Pipeline run identifier (e.g. "etl_build", "manual", "ci").
+    """
+
+    __tablename__ = "canonical_player_snapshots"
+    __table_args__ = (
+        UniqueConstraint("season", "content_digest", name="uq_snapshot_season_digest"),
+        Index("ix_canonical_player_snapshot_season", "season"),
+        Index("ix_canonical_player_snapshot_created", "created_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    season = Column(Integer, nullable=False, index=True)
+    content_digest = Column(String(64), nullable=False)
+    total_rows = Column(Integer, nullable=False, default=0)
+    unique_player_ids = Column(Integer, nullable=False, default=0)
+    deduplicated_rows = Column(Integer, nullable=False, default=0)
+    duplicate_name_keys = Column(JSON, nullable=False, default=list)
+    position_distribution = Column(JSON, nullable=False, default=dict)
+    source = Column(String(32), nullable=False, default="etl_build")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/scripts/daily_sync.py
+++ b/backend/scripts/daily_sync.py
@@ -16,10 +16,18 @@ try:
 except ModuleNotFoundError:
     from services import player_service
 try:
-    from backend.services.player_identity_service import current_season, upsert_player_season
+    from backend.services.player_identity_service import (
+        current_season,
+        deactivate_stale_player_seasons,
+        upsert_player_season,
+    )
     from backend.services.nfl_roster_provider_service import fetch_current_players
 except ModuleNotFoundError:
-    from services.player_identity_service import current_season, upsert_player_season
+    from services.player_identity_service import (
+        current_season,
+        deactivate_stale_player_seasons,
+        upsert_player_season,
+    )
     from services.nfl_roster_provider_service import fetch_current_players
 
 def sync_nfl_reality():
@@ -36,6 +44,9 @@ def sync_nfl_reality():
     active_players = df[df['status'] == 'Active']
     
     season = current_season()
+    # Collect the set of local player IDs confirmed active in this feed run.
+    # Used after the loop to deactivate players absent from the current roster.
+    seen_player_ids: set[int] = set()
 
     for _, row in active_players.iterrows():
         name = row.get('display_name') or row.get('player_name') or row.get('first_name')
@@ -82,7 +93,20 @@ def sync_nfl_reality():
                 is_active=True,
                 source="nfl_daily_sync",
             )
-    
+            seen_player_ids.add(int(player.id))
+
+    # --- Deactivation pass ---
+    # Any player with an active PlayerSeason this year who did NOT appear in
+    # today's feed is presumed retired/cut/IR.  DEF rows are excluded.
+    # The threshold guard (100) prevents mass-deactivation from a bad fetch.
+    deactivated = deactivate_stale_player_seasons(
+        db,
+        season=season,
+        active_player_ids=seen_player_ids,
+    )
+    if deactivated:
+        print(f"🚫 Marked {deactivated} player-season(s) inactive (absent from feed)")
+
     db.commit()
     print("✨ NFL Reality Sync Complete.")
 

--- a/backend/services/player_identity_service.py
+++ b/backend/services/player_identity_service.py
@@ -98,3 +98,52 @@ def ensure_primary_alias(db: Session, *, player_id: int, player_name: str) -> No
         source="canonical",
         is_primary=True,
     )
+
+
+def deactivate_stale_player_seasons(
+    db: Session,
+    *,
+    season: int,
+    active_player_ids: set[int],
+    min_active_threshold: int = 100,
+) -> int:
+    """Set ``is_active=False`` on PlayerSeason rows that were absent from the
+    current sync feed.
+
+    Only non-DEF players are considered — defense rows are never deactivated
+    via feed comparison because they are not reliably present in ESPN player
+    lists.  The caller must guarantee that ``active_player_ids`` is the full
+    set of local ``players.id`` values seen in the feed for this season; any
+    player NOT in that set and currently marked active will be deactivated.
+
+    A minimum threshold guard prevents mass-deactivation when the upstream
+    feed returns a suspiciously small payload (bad fetch / partial response).
+
+    Returns the number of rows deactivated.
+    """
+    if len(active_player_ids) < min_active_threshold:
+        return 0
+
+    # Fetch all currently-active non-DEF seasons for this season year.
+    stale_rows = (
+        db.query(models.PlayerSeason)
+        .join(models.Player, models.Player.id == models.PlayerSeason.player_id)
+        .filter(
+            models.PlayerSeason.season == int(season),
+            models.PlayerSeason.is_active.is_(True),
+            models.Player.position != "DEF",
+        )
+        .all()
+    )
+
+    deactivated = 0
+    for row in stale_rows:
+        if int(row.player_id) not in active_player_ids:
+            row.is_active = False
+            row.source = "nfl_daily_sync_deactivated"
+            deactivated += 1
+
+    if deactivated:
+        db.flush()
+
+    return deactivated

--- a/backend/tests/test_players_router.py
+++ b/backend/tests/test_players_router.py
@@ -7,6 +7,10 @@ from sqlalchemy import text
 from backend.database import SessionLocal
 import backend.models as models
 from backend.core import security
+from backend.services.player_identity_service import (
+    deactivate_stale_player_seasons,
+    upsert_player_season,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1219,6 +1223,129 @@ def test_top_free_agents_returns_ranked_players_with_reasons(client):
         cleanup = SessionLocal()
         try:
             cleanup.query(models.WaiverClaim).filter(models.WaiverClaim.player_id.in_(created_ids)).delete(synchronize_session=False)
+            cleanup.query(models.Player).filter(models.Player.id.in_(created_ids)).delete(synchronize_session=False)
+            cleanup.commit()
+        finally:
+            cleanup.close()
+
+
+# ---------------------------------------------------------------------------
+# deactivate_stale_player_seasons tests
+# ---------------------------------------------------------------------------
+
+def test_deactivate_stale_player_seasons_marks_absent_players_inactive():
+    """Players not in the active feed set should have is_active flipped to False."""
+    suffix = uuid4().hex[:8]
+    season = 2099  # isolated test season unlikely to clash
+
+    db = SessionLocal()
+    created_ids = []
+    try:
+        # Create two players: one will be "seen" in the feed, one will be absent.
+        p_active = models.Player(name=f"Active Player {suffix}", position="WR", nfl_team="GB")
+        p_gone = models.Player(name=f"Retired Player {suffix}", position="RB", nfl_team="NE")
+        db.add_all([p_active, p_gone])
+        db.flush()
+        created_ids.extend([int(p_active.id), int(p_gone.id)])
+
+        upsert_player_season(db, player_id=p_active.id, season=season, nfl_team="GB", position="WR", bye_week=None, is_active=True, source="test")
+        upsert_player_season(db, player_id=p_gone.id, season=season, nfl_team="NE", position="RB", bye_week=None, is_active=True, source="test")
+        db.flush()
+
+        # Only p_active appears in today's feed.
+        deactivated = deactivate_stale_player_seasons(
+            db,
+            season=season,
+            active_player_ids={int(p_active.id)},
+            min_active_threshold=1,
+        )
+
+        assert deactivated == 1
+        gone_season = db.query(models.PlayerSeason).filter_by(player_id=int(p_gone.id), season=season).first()
+        active_season = db.query(models.PlayerSeason).filter_by(player_id=int(p_active.id), season=season).first()
+        assert gone_season.is_active is False
+        assert active_season.is_active is True
+    finally:
+        db.rollback()
+        cleanup = SessionLocal()
+        try:
+            cleanup.query(models.PlayerSeason).filter(models.PlayerSeason.player_id.in_(created_ids)).delete(synchronize_session=False)
+            cleanup.query(models.Player).filter(models.Player.id.in_(created_ids)).delete(synchronize_session=False)
+            cleanup.commit()
+        finally:
+            cleanup.close()
+
+
+def test_deactivate_stale_player_seasons_skips_def_rows():
+    """DEF player-seasons must never be deactivated by the feed comparison."""
+    suffix = uuid4().hex[:8]
+    season = 2099
+
+    db = SessionLocal()
+    created_ids = []
+    try:
+        p_def = models.Player(name=f"SF Defense {suffix}", position="DEF", nfl_team="SF")
+        db.add(p_def)
+        db.flush()
+        created_ids.append(int(p_def.id))
+
+        upsert_player_season(db, player_id=p_def.id, season=season, nfl_team="SF", position="DEF", bye_week=None, is_active=True, source="test")
+        db.flush()
+
+        # DEF not in the feed — but should NOT be deactivated.
+        deactivated = deactivate_stale_player_seasons(
+            db,
+            season=season,
+            active_player_ids=set(),
+            min_active_threshold=0,
+        )
+
+        assert deactivated == 0
+        def_season = db.query(models.PlayerSeason).filter_by(player_id=int(p_def.id), season=season).first()
+        assert def_season.is_active is True
+    finally:
+        db.rollback()
+        cleanup = SessionLocal()
+        try:
+            cleanup.query(models.PlayerSeason).filter(models.PlayerSeason.player_id.in_(created_ids)).delete(synchronize_session=False)
+            cleanup.query(models.Player).filter(models.Player.id.in_(created_ids)).delete(synchronize_session=False)
+            cleanup.commit()
+        finally:
+            cleanup.close()
+
+
+def test_deactivate_stale_player_seasons_threshold_guard():
+    """If feed returns fewer players than min_active_threshold, nothing is deactivated."""
+    suffix = uuid4().hex[:8]
+    season = 2099
+
+    db = SessionLocal()
+    created_ids = []
+    try:
+        p = models.Player(name=f"QB Threshold {suffix}", position="QB", nfl_team="KC")
+        db.add(p)
+        db.flush()
+        created_ids.append(int(p.id))
+
+        upsert_player_season(db, player_id=p.id, season=season, nfl_team="KC", position="QB", bye_week=None, is_active=True, source="test")
+        db.flush()
+
+        # Feed has 0 players — below default threshold of 100, so guard fires.
+        deactivated = deactivate_stale_player_seasons(
+            db,
+            season=season,
+            active_player_ids=set(),
+            min_active_threshold=100,
+        )
+
+        assert deactivated == 0
+        season_row = db.query(models.PlayerSeason).filter_by(player_id=int(p.id), season=season).first()
+        assert season_row.is_active is True
+    finally:
+        db.rollback()
+        cleanup = SessionLocal()
+        try:
+            cleanup.query(models.PlayerSeason).filter(models.PlayerSeason.player_id.in_(created_ids)).delete(synchronize_session=False)
             cleanup.query(models.Player).filter(models.Player.id.in_(created_ids)).delete(synchronize_session=False)
             cleanup.commit()
         finally:

--- a/db/migrations/0022_add_position_and_snapshot_tables.py
+++ b/db/migrations/0022_add_position_and_snapshot_tables.py
@@ -112,5 +112,10 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table('canonical_player_snapshots')
-    op.drop_table('positions')
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+    if 'canonical_player_snapshots' in table_names:
+        op.drop_table('canonical_player_snapshots')
+    if 'positions' in table_names:
+        op.drop_table('positions')

--- a/db/migrations/0022_add_position_and_snapshot_tables.py
+++ b/db/migrations/0022_add_position_and_snapshot_tables.py
@@ -1,0 +1,116 @@
+"""
+issue #103 phase 2: position registry and canonical player snapshot tables
+"""
+
+revision = '0022_add_position_and_snapshot_tables'
+down_revision = '0021_add_league_settings_trade_governance_columns'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Canonical active positions seeded into the positions table on first run.
+_ACTIVE_POSITIONS = [
+    ("QB",   "Quarterback",    True,  1),
+    ("RB",   "Running Back",   True,  2),
+    ("WR",   "Wide Receiver",  True,  3),
+    ("TE",   "Tight End",      True,  4),
+    ("K",    "Kicker",         True,  5),
+    ("DEF",  "Defense/ST",     True,  6),
+    ("FLEX", "Flex",           True,  7),
+]
+
+# Legacy/inactive position tokens that may exist in historical data.
+_INACTIVE_POSITIONS = [
+    ("D/ST",    "Defense/ST (legacy)",   False, None),
+    ("DST",     "Defense/ST (alt)",      False, None),
+    ("DEFENSE", "Defense (verbose)",     False, None),
+    ("TD",      "TD (legacy MFL)",       False, None),
+    ("PK",      "Kicker (legacy MFL)",   False, None),
+    ("KICKER",  "Kicker (verbose)",      False, None),
+    ("UNKNOWN", "Unknown",               False, None),
+]
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+
+    # ------------------------------------------------------------------
+    # 1. positions table
+    # ------------------------------------------------------------------
+    if 'positions' not in table_names:
+        op.create_table(
+            'positions',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('abbreviation', sa.String(8), nullable=False),
+            sa.Column('label', sa.String(64), nullable=True),
+            sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column('source', sa.String(32), nullable=False, server_default='canonical'),
+            sa.Column('sort_order', sa.Integer(), nullable=True),
+            sa.Column(
+                'created_at',
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text('now()'),
+            ),
+            sa.Column(
+                'updated_at',
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text('now()'),
+            ),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('abbreviation', name='uq_positions_abbreviation'),
+        )
+        op.create_index('ix_positions_abbreviation', 'positions', ['abbreviation'], unique=True)
+
+        # Seed active positions
+        positions_table = sa.table(
+            'positions',
+            sa.column('abbreviation', sa.String),
+            sa.column('label', sa.String),
+            sa.column('is_active', sa.Boolean),
+            sa.column('source', sa.String),
+            sa.column('sort_order', sa.Integer),
+        )
+        rows = [
+            {'abbreviation': abbr, 'label': label, 'is_active': active, 'source': 'canonical', 'sort_order': sort}
+            for abbr, label, active, sort in _ACTIVE_POSITIONS + _INACTIVE_POSITIONS
+        ]
+        op.bulk_insert(positions_table, rows)
+
+    # ------------------------------------------------------------------
+    # 2. canonical_player_snapshots table
+    # ------------------------------------------------------------------
+    if 'canonical_player_snapshots' not in table_names:
+        op.create_table(
+            'canonical_player_snapshots',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('season', sa.Integer(), nullable=False),
+            sa.Column('content_digest', sa.String(64), nullable=False),
+            sa.Column('total_rows', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('unique_player_ids', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('deduplicated_rows', sa.Integer(), nullable=False, server_default='0'),
+            sa.Column('duplicate_name_keys', sa.JSON(), nullable=False, server_default='[]'),
+            sa.Column('position_distribution', sa.JSON(), nullable=False, server_default='{}'),
+            sa.Column('source', sa.String(32), nullable=False, server_default='etl_build'),
+            sa.Column(
+                'created_at',
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text('now()'),
+            ),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('season', 'content_digest', name='uq_snapshot_season_digest'),
+        )
+        op.create_index('ix_canonical_player_snapshot_season', 'canonical_player_snapshots', ['season'])
+        op.create_index('ix_canonical_player_snapshot_created', 'canonical_player_snapshots', ['created_at'])
+
+
+def downgrade():
+    op.drop_table('canonical_player_snapshots')
+    op.drop_table('positions')

--- a/etl/transform/player_metadata_alias_map.yml
+++ b/etl/transform/player_metadata_alias_map.yml
@@ -1,10 +1,161 @@
-# Canonical aliases for player display names. Keys/values are authored in title case for readability.
-# Aliases are applied to raw source names, then canonical names are normalized by the ETL pipeline.
-# This map is intentionally small for v1 and can be expanded from real QA findings.
+# Canonical aliases for player display names.
+# Keys are raw source names; values are the preferred canonical display names.
+# These are applied BEFORE normalize_player_name(), so only add entries where
+# normalization alone would NOT resolve the mismatch (e.g. genuine nickname
+# differences, shortened first names, or variant spellings across sources).
+#
+# Do NOT add entries where the only difference is punctuation (periods,
+# apostrophes, commas) or common suffixes (Jr, Sr, II, III, IV) — the
+# normalize_player_name() function already strips those.
+#
+# Format:  "Raw Source Name": "Canonical Name"
+# Sources: MFL, ESPN, Yahoo, DraftSharks, FantasyNerds cross-ref QA
 aliases:
+  # ── Punctuation / initials already handled by normalize, kept for
+  #    backward-compat with any source that skips normalization ─────────────
   A.J. Green: AJ Green
   A.J. Brown: AJ Brown
   D.K. Metcalf: DK Metcalf
   T.Y. Hilton: TY Hilton
   Odell Beckham Jr.: Odell Beckham
   Robert Griffin III: Robert Griffin
+
+  # ── Shortened first names (ESPN uses full; MFL/Yahoo abbreviate) ─────────
+  Gabriel Davis: Gabe Davis
+  Scotty Miller: Scott Miller
+  Robbie Anderson: Robbie Anderson         # alias for "Rob Anderson" on MFL
+  Rob Anderson: Robbie Anderson
+  Michael Pittman: Michael Pittman Jr      # ESPN drops Jr, MFL keeps it
+  Michael Pittman Jr.: Michael Pittman Jr
+  Marvin Harrison: Marvin Harrison Jr      # ESPN drops Jr
+  Marvin Harrison Jr.: Marvin Harrison Jr
+  Brian Robinson: Brian Robinson Jr        # ESPN drops Jr
+  Brian Robinson Jr.: Brian Robinson Jr
+  Duke Johnson: Duke Johnson Jr            # ESPN drops Jr
+  Duke Johnson Jr.: Duke Johnson Jr
+  Mecole Hardman: Mecole Hardman Jr        # ESPN drops Jr
+  Mecole Hardman Jr.: Mecole Hardman Jr
+
+  # ── Nicknames used as primary name on some platforms ────────────────────
+  Hollywood Brown: Marquise Brown          # MFL uses nickname; ESPN uses legal
+  Marquise Brown: Marquise Brown           # passthrough
+  Cordarrelle Patterson: C.J. Patterson    # some sources abbreviate
+  C.J. Patterson: Cordarrelle Patterson
+  Laviska Shenault Jr: Laviska Shenault    # Jr dropped on some sources
+  Laviska Shenault Jr.: Laviska Shenault
+
+  # ── Hyphenated / compound surnames ──────────────────────────────────────
+  Ke'Shawn Vaughn: Keshawn Vaughn
+  Keshawn Vaughn: Keshawn Vaughn           # passthrough after apostrophe strip
+  De'Von Achane: Devon Achane
+  Devon Achane: Devon Achane
+  Za'Darius Smith: Zadarius Smith
+  Zadarius Smith: Zadarius Smith
+  Tre'Quan Smith: Trequan Smith
+  Trequan Smith: Trequan Smith
+  Ja'Marr Chase: Jamarr Chase
+  Jamarr Chase: Jamarr Chase
+  De'Anthony Thomas: Deanthony Thomas
+  Deanthony Thomas: Deanthony Thomas
+
+  # ── Defense / ST naming variants across sources ──────────────────────────
+  San Francisco 49ers: SF
+  San Francisco Defense: SF
+  San Francisco 49ers D/ST: SF
+  New England Patriots: NE
+  New England Defense: NE
+  New England Patriots D/ST: NE
+  Kansas City Chiefs: KC
+  Kansas City Defense: KC
+  Kansas City Chiefs D/ST: KC
+  Dallas Cowboys: DAL
+  Dallas Cowboys Defense: DAL
+  Dallas Cowboys D/ST: DAL
+  Philadelphia Eagles: PHI
+  Philadelphia Defense: PHI
+  Philadelphia Eagles D/ST: PHI
+  Baltimore Ravens: BAL
+  Baltimore Defense: BAL
+  Baltimore Ravens D/ST: BAL
+  Buffalo Bills: BUF
+  Buffalo Defense: BUF
+  Buffalo Bills D/ST: BUF
+  Miami Dolphins: MIA
+  Miami Defense: MIA
+  Miami Dolphins D/ST: MIA
+  Minnesota Vikings: MIN
+  Minnesota Defense: MIN
+  Minnesota Vikings D/ST: MIN
+  Green Bay Packers: GB
+  Green Bay Defense: GB
+  Green Bay Packers D/ST: GB
+  Los Angeles Rams: LAR
+  Los Angeles Rams Defense: LAR
+  Los Angeles Rams D/ST: LAR
+  Los Angeles Chargers: LAC
+  Los Angeles Chargers Defense: LAC
+  Los Angeles Chargers D/ST: LAC
+  Chicago Bears: CHI
+  Chicago Defense: CHI
+  Chicago Bears D/ST: CHI
+  New York Giants: NYG
+  New York Giants Defense: NYG
+  New York Giants D/ST: NYG
+  New York Jets: NYJ
+  New York Jets Defense: NYJ
+  New York Jets D/ST: NYJ
+  Pittsburgh Steelers: PIT
+  Pittsburgh Defense: PIT
+  Pittsburgh Steelers D/ST: PIT
+  Cleveland Browns: CLE
+  Cleveland Defense: CLE
+  Cleveland Browns D/ST: CLE
+  Cincinnati Bengals: CIN
+  Cincinnati Defense: CIN
+  Cincinnati Bengals D/ST: CIN
+  Indianapolis Colts: IND
+  Indianapolis Defense: IND
+  Indianapolis Colts D/ST: IND
+  Tennessee Titans: TEN
+  Tennessee Defense: TEN
+  Tennessee Titans D/ST: TEN
+  Houston Texans: HOU
+  Houston Defense: HOU
+  Houston Texans D/ST: HOU
+  Jacksonville Jaguars: JAX
+  Jacksonville Defense: JAX
+  Jacksonville Jaguars D/ST: JAX
+  Denver Broncos: DEN
+  Denver Defense: DEN
+  Denver Broncos D/ST: DEN
+  Las Vegas Raiders: LV
+  Las Vegas Raiders Defense: LV
+  Las Vegas Raiders D/ST: LV
+  Oakland Raiders: OAK
+  Oakland Raiders Defense: OAK
+  Seattle Seahawks: SEA
+  Seattle Defense: SEA
+  Seattle Seahawks D/ST: SEA
+  Arizona Cardinals: ARI
+  Arizona Defense: ARI
+  Arizona Cardinals D/ST: ARI
+  Atlanta Falcons: ATL
+  Atlanta Defense: ATL
+  Atlanta Falcons D/ST: ATL
+  Carolina Panthers: CAR
+  Carolina Defense: CAR
+  Carolina Panthers D/ST: CAR
+  New Orleans Saints: NO
+  New Orleans Defense: NO
+  New Orleans Saints D/ST: NO
+  Tampa Bay Buccaneers: TB
+  Tampa Bay Defense: TB
+  Tampa Bay Buccaneers D/ST: TB
+  Washington Commanders: WAS
+  Washington Commanders Defense: WAS
+  Washington Commanders D/ST: WAS
+  Washington Redskins: WAS
+  Washington Football Team: WAS
+  Detroit Lions: DET
+  Detroit Defense: DET
+  Detroit Lions D/ST: DET


### PR DESCRIPTION
## Summary

Closes part of #103 (Phase 2 deliverables). Tracked under parent #361.

This PR delivers four discrete changes that advance the canonical player metadata foundation:

---

### 1. `Position` ORM model + migration seed

- New `positions` table (`backend/models.py`) with `abbreviation`, `label`, `is_active`, `sort_order`, `source`
- Migration `0022` (`db/migrations/0022_add_position_and_snapshot_tables.py`) — idempotent; seeds 7 active tokens (QB, RB, WR, TE, K, DEF, FLEX) and 7 inactive/legacy tokens (D/ST, DST, DEFENSE, TD, PK, KICKER, UNKNOWN)

### 2. `CanonicalPlayerSnapshot` ORM model

- New `canonical_player_snapshots` table — captures per-season dedup stats, position distribution JSON, and a content digest for idempotency checks
- UniqueConstraint on `(season, content_digest)` prevents duplicate snapshot rows
- Schema designed for ETL write-back (see follow-up #PLACEHOLDER_ETL)

### 3. Expanded alias map (138 entries)

- `etl/transform/player_metadata_alias_map.yml` expanded from 6 → 138 entries
- Coverage: Jr suffix passthroughs, shortened first names (`Gabriel Davis → Gabe Davis`), nickname→legal (`Hollywood Brown → Marquise Brown`), apostrophe-name normalisations (`Ja'Marr Chase → Jamarr Chase`), and all 32 team D/ST naming variants (ESPN full name, "Defense", "D/ST" → team abbreviation)
- Validated: no duplicate keys; 138 entries load cleanly

### 4. Stale-player deactivation pass in daily ESPN sync

- New `deactivate_stale_player_seasons()` in `backend/services/player_identity_service.py`
  - Set-difference logic: any non-DEF `PlayerSeason` row for the current season that was absent from today's ESPN feed is flipped to `is_active = False`
  - DEF rows exempt (defenses don't appear consistently in ESPN player feeds)
  - `min_active_threshold` guard (default 100) prevents mass-deactivation from partial/bad upstream responses
- Wired into `sync_nfl_reality()` in `backend/scripts/daily_sync.py`
- 3 new tests (all passing): absent→inactive, DEF skip, threshold guard

---

## Testing

```
.venv/bin/pytest backend/tests/test_players_router.py -k "deactivate_stale" -v
# 3 passed
```

## Follow-up issues (not in scope for this PR)

- ETL write-back: populate `canonical_player_snapshots` rows from the canonicalization pipeline output (see #361)
- API / frontend exposure of the `Position` registry (new issue to be filed)
