### PR TITLE
feat(#104): owner budget behavior features, OwnerSeasonBehavior model, and migration 0023

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1026,4 +1026,54 @@ class MflIngestionFile(Base):
     sha256 = Column(String(64), nullable=True)
     retention_class = Column(String(32), nullable=True)
     archived_path = Column(String, nullable=True)
+
+
+# ---------------------------------------------------------------------------
+# ISSUE #104 — Owner Budget Behavior Features
+# ---------------------------------------------------------------------------
+
+class OwnerSeasonBehavior(Base):
+    """Per-owner-per-season behavioral feature aggregate derived from draft spend.
+
+    Populated by the ETL behavior feature pass (etl/transform/owner_budget_timeline.py).
+    Consumed downstream by ML feature engineering (#106) and draft analyzer (#109).
+    """
+
+    __tablename__ = "owner_season_behaviors"
+    __table_args__ = (
+        UniqueConstraint("league_id", "owner_id", "season_year", name="uq_osb_league_owner_season"),
+        Index("ix_osb_league_season", "league_id", "season_year"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    league_id = Column(Integer, ForeignKey("leagues.id"), nullable=True)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    season_year = Column(Integer, nullable=False, index=True)
+
+    # Budget reconciliation fields
+    starting_budget = Column(Numeric(10, 2), nullable=True)
+    total_spend = Column(Numeric(10, 2), nullable=True)
+    remaining_budget = Column(Numeric(10, 2), nullable=True)
+    budget_source = Column(String(32), nullable=True)  # exact / carry_forward / carry_backward / global_default
+    overspent = Column(Boolean, nullable=True)
+
+    # Positional breakdown (JSON dicts keyed by position abbreviation, e.g. "QB")
+    spend_by_position = Column(JSON, nullable=True)       # {"QB": 45.0, "RB": 87.0, ...}
+    pick_count_by_position = Column(JSON, nullable=True)  # {"QB": 2, "RB": 5, ...}
+    position_spend_pct = Column(JSON, nullable=True)      # {"QB": 0.23, "RB": 0.44, ...}
+    max_bid_by_position = Column(JSON, nullable=True)     # {"QB": 42.0, "RB": 55.0, ...}
+    avg_bid_by_position = Column(JSON, nullable=True)     # {"QB": 22.5, "RB": 17.4, ...}
+
+    # Scalar behavioral indices
+    # aggressiveness_index: fraction of total spend concentrated in the owner's
+    # top-quartile bids (0–1; higher = more concentrated / aggressive top picks)
+    aggressiveness_index = Column(Float, nullable=True)
+    # positional_bias_index: mean absolute deviation of owner's positional spend
+    # percentages from the league-average percentages for that season (0–1)
+    positional_bias_index = Column(Float, nullable=True)
+
+    # Audit
+    etl_version = Column(String(32), nullable=True)   # e.g. "v1"
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/db/migrations/0023_add_owner_season_behavior_table.py
+++ b/db/migrations/0023_add_owner_season_behavior_table.py
@@ -1,0 +1,80 @@
+"""add owner_season_behaviors table for draft spend behavioral features
+
+Revision ID: 0023
+Revises: 0022_add_position_and_snapshot_tables
+Create Date: 2026-05-02
+
+Note: depends on migration 0022 which is in PR #450. Apply after that PR merges.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0023"
+down_revision = "0022_add_position_and_snapshot_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "owner_season_behaviors" not in inspector.get_table_names():
+        op.create_table(
+            "owner_season_behaviors",
+            sa.Column("id", sa.Integer(), primary_key=True, index=True, nullable=False),
+            sa.Column("league_id", sa.Integer(), sa.ForeignKey("leagues.id"), nullable=True),
+            sa.Column("owner_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("season_year", sa.Integer(), nullable=False),
+            sa.Column("starting_budget", sa.Numeric(10, 2), nullable=True),
+            sa.Column("total_spend", sa.Numeric(10, 2), nullable=True),
+            sa.Column("remaining_budget", sa.Numeric(10, 2), nullable=True),
+            sa.Column("budget_source", sa.String(32), nullable=True),
+            sa.Column("overspent", sa.Boolean(), nullable=True),
+            sa.Column("spend_by_position", sa.JSON(), nullable=True),
+            sa.Column("pick_count_by_position", sa.JSON(), nullable=True),
+            sa.Column("position_spend_pct", sa.JSON(), nullable=True),
+            sa.Column("max_bid_by_position", sa.JSON(), nullable=True),
+            sa.Column("avg_bid_by_position", sa.JSON(), nullable=True),
+            sa.Column("aggressiveness_index", sa.Float(), nullable=True),
+            sa.Column("positional_bias_index", sa.Float(), nullable=True),
+            sa.Column("etl_version", sa.String(32), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                onupdate=sa.func.now(),
+                nullable=False,
+            ),
+        )
+
+        op.create_unique_constraint(
+            "uq_osb_league_owner_season",
+            "owner_season_behaviors",
+            ["league_id", "owner_id", "season_year"],
+        )
+        op.create_index(
+            "ix_osb_league_season",
+            "owner_season_behaviors",
+            ["league_id", "season_year"],
+        )
+        op.create_index(
+            "ix_owner_season_behaviors_season_year",
+            "owner_season_behaviors",
+            ["season_year"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "owner_season_behaviors" in inspector.get_table_names():
+        op.drop_table("owner_season_behaviors")

--- a/etl/build_phase1_artifacts.py
+++ b/etl/build_phase1_artifacts.py
@@ -11,7 +11,10 @@ import pandas as pd
 from sqlalchemy import create_engine, inspect
 
 from etl.transform.historical_draft_validator import write_draft_validation_outputs_from_dataframes
-from etl.transform.owner_budget_timeline import write_budget_timeline_outputs_from_dataframes
+from etl.transform.owner_budget_timeline import (
+    write_budget_timeline_outputs_from_dataframes,
+    write_behavior_feature_outputs_from_dataframes,
+)
 from etl.transform.player_metadata_canonicalization import write_canonicalization_outputs_from_dataframes
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -215,6 +218,14 @@ def main() -> int:
         output_dir=OUTPUT_DIR / "owner_budget",
     )
 
+    behavior_output = write_behavior_feature_outputs_from_dataframes(
+        draft_budget_df=frames["draft_budget"],
+        draft_results_df=frames["draft_results"],
+        users_df=frames["users"],
+        positions_df=frames["positions"],
+        output_dir=OUTPUT_DIR / "owner_budget",
+    )
+
     draft_validation_output = write_draft_validation_outputs_from_dataframes(
         draft_results_df=frames["draft_results"],
         players_df=frames["players"],
@@ -237,6 +248,11 @@ def main() -> int:
         "csv": _manifest_rel(budget_output["csv"]),
         "report": _manifest_rel(budget_output["report"]),
     }
+    behavior_manifest = {
+        **behavior_output,
+        "behavior_csv": _manifest_rel(behavior_output["behavior_csv"]),
+        "behavior_report": _manifest_rel(behavior_output["behavior_report"]),
+    }
     draft_validation_manifest = {
         **draft_validation_output,
         "csv": _manifest_rel(draft_validation_output["csv"]),
@@ -251,6 +267,7 @@ def main() -> int:
         "artifacts": {
             "361_player_metadata": canonical_manifest,
             "362_owner_budget_timeline": budget_manifest,
+            "362_owner_behavior_features": behavior_manifest,
             "363_historical_draft_validation": draft_validation_manifest,
         },
     }

--- a/etl/test_phase1_artifacts.py
+++ b/etl/test_phase1_artifacts.py
@@ -1,7 +1,10 @@
 import pandas as pd
 
 from etl.transform.historical_draft_validator import validate_historical_draft_results
-from etl.transform.owner_budget_timeline import build_owner_budget_timeline
+from etl.transform.owner_budget_timeline import (
+    build_owner_behavior_features,
+    build_owner_budget_timeline,
+)
 from etl.transform.player_metadata_canonicalization import canonicalize_player_metadata
 
 
@@ -87,3 +90,114 @@ def test_historical_draft_validator_flags_duplicates_and_missing_refs():
     assert report["error_count"] >= 3
     assert not correction_df.empty
     assert len(validated_df) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_owner_behavior_features
+# ---------------------------------------------------------------------------
+
+def _make_behavior_fixtures():
+    """Minimal but realistic set of DataFrames for behavior feature tests."""
+    draft_budget = pd.DataFrame([
+        {"OwnerID": 10, "Year": 2025, "DraftBudget": 200},
+        {"OwnerID": 11, "Year": 2025, "DraftBudget": 200},
+    ])
+    # Owner 10 spends $100 on QB, $60 on RB, $40 on WR (total 200)
+    # Owner 11 spends $80 on RB, $20 on TE (total 100)
+    draft_results = pd.DataFrame([
+        {"PlayerID": 1001, "OwnerID": 10, "Year": 2025, "WinningBid": "$100.00", "PositionID": 8002},
+        {"PlayerID": 1002, "OwnerID": 10, "Year": 2025, "WinningBid": "$60.00",  "PositionID": 8003},
+        {"PlayerID": 1003, "OwnerID": 10, "Year": 2025, "WinningBid": "$40.00",  "PositionID": 8004},
+        {"PlayerID": 1004, "OwnerID": 11, "Year": 2025, "WinningBid": "$80.00",  "PositionID": 8003},
+        {"PlayerID": 1005, "OwnerID": 11, "Year": 2025, "WinningBid": "$20.00",  "PositionID": 8005},
+    ])
+    users = pd.DataFrame([
+        {"OwnerID": 10, "OwnerName": "Alice"},
+        {"OwnerID": 11, "OwnerName": "Bob"},
+    ])
+    positions = pd.DataFrame([
+        {"PositionID": 8002, "Position": "QB"},
+        {"PositionID": 8003, "Position": "RB"},
+        {"PositionID": 8004, "Position": "WR"},
+        {"PositionID": 8005, "Position": "TE"},
+    ])
+    return draft_budget, draft_results, users, positions
+
+
+def test_build_owner_behavior_features_returns_one_row_per_owner_season():
+    draft_budget, draft_results, users, positions = _make_behavior_fixtures()
+    timeline, _ = build_owner_budget_timeline(draft_budget, draft_results, users)
+    behavior_df, report = build_owner_behavior_features(timeline, draft_results, positions)
+
+    assert len(behavior_df) == 2
+    assert report["owner_season_pairs"] == 2
+    assert set(behavior_df["owner_id"].tolist()) == {10, 11}
+
+
+def test_build_owner_behavior_features_positional_spend_sums_to_total():
+    draft_budget, draft_results, users, positions = _make_behavior_fixtures()
+    timeline, _ = build_owner_budget_timeline(draft_budget, draft_results, users)
+    behavior_df, _ = build_owner_behavior_features(timeline, draft_results, positions)
+
+    owner10 = behavior_df[behavior_df["owner_id"] == 10].iloc[0]
+    pos_spend = owner10["spend_by_position"]
+    assert abs(sum(pos_spend.values()) - float(owner10["total_spend"])) < 0.01
+    assert pos_spend["QB"] == 100.0
+    assert pos_spend["RB"] == 60.0
+
+
+def test_build_owner_behavior_features_position_spend_pct_sums_to_one():
+    draft_budget, draft_results, users, positions = _make_behavior_fixtures()
+    timeline, _ = build_owner_budget_timeline(draft_budget, draft_results, users)
+    behavior_df, _ = build_owner_behavior_features(timeline, draft_results, positions)
+
+    for _, row in behavior_df.iterrows():
+        pct_sum = sum(row["position_spend_pct"].values())
+        assert abs(pct_sum - 1.0) < 1e-4, f"owner {row['owner_id']} pct sum={pct_sum}"
+
+
+def test_build_owner_behavior_features_aggressiveness_index_between_0_and_1():
+    draft_budget, draft_results, users, positions = _make_behavior_fixtures()
+    timeline, _ = build_owner_budget_timeline(draft_budget, draft_results, users)
+    behavior_df, _ = build_owner_behavior_features(timeline, draft_results, positions)
+
+    owner10 = behavior_df[behavior_df["owner_id"] == 10].iloc[0]
+    agg = owner10["aggressiveness_index"]
+    assert agg is not None
+    assert 0.0 <= agg <= 1.0
+    # Owner 10 has 3 picks; top quartile = 1 pick ($100 of $200 = 0.5)
+    assert abs(agg - 0.5) < 1e-4
+
+
+def test_build_owner_behavior_features_positional_bias_index_non_negative():
+    draft_budget, draft_results, users, positions = _make_behavior_fixtures()
+    timeline, _ = build_owner_budget_timeline(draft_budget, draft_results, users)
+    behavior_df, _ = build_owner_behavior_features(timeline, draft_results, positions)
+
+    for _, row in behavior_df.iterrows():
+        pbi = row["positional_bias_index"]
+        assert pbi is not None
+        assert pbi >= 0.0, f"owner {row['owner_id']} pbi={pbi}"
+
+
+def test_build_owner_behavior_features_empty_input_returns_empty_df():
+    empty_dr = pd.DataFrame(columns=["PlayerID", "OwnerID", "Year", "WinningBid", "PositionID"])
+    positions = pd.DataFrame([{"PositionID": 8002, "Position": "QB"}])
+    timeline = pd.DataFrame()
+    behavior_df, report = build_owner_behavior_features(timeline, empty_dr, positions)
+
+    assert behavior_df.empty
+    assert report["owner_season_pairs"] == 0
+    assert report["behavior_rows"] == 0
+
+
+def test_build_owner_behavior_features_is_idempotent():
+    """Running twice on identical input produces byte-equivalent output."""
+    draft_budget, draft_results, users, positions = _make_behavior_fixtures()
+    timeline, _ = build_owner_budget_timeline(draft_budget, draft_results, users)
+
+    df1, r1 = build_owner_behavior_features(timeline, draft_results, positions)
+    df2, r2 = build_owner_behavior_features(timeline, draft_results, positions)
+
+    assert df1.to_csv(index=False) == df2.to_csv(index=False)
+    assert r1["owner_season_pairs"] == r2["owner_season_pairs"]

--- a/etl/transform/owner_budget_timeline.py
+++ b/etl/transform/owner_budget_timeline.py
@@ -203,6 +203,223 @@ def build_owner_budget_timeline(
     return timeline_df, report
 
 
+def build_owner_behavior_features(
+    timeline_df: pd.DataFrame,
+    draft_results_df: pd.DataFrame,
+    positions_df: pd.DataFrame,
+    *,
+    etl_version: str = "v1",
+) -> tuple[pd.DataFrame, dict[str, Any]]:
+    """Compute per-owner-per-season behavioral features from the draft spend timeline.
+
+    Parameters
+    ----------
+    timeline_df:
+        Output of ``build_owner_budget_timeline`` — one row per draft pick event.
+    draft_results_df:
+        Source draft results with ``OwnerID``, ``Year``, ``WinningBid``, ``PositionID``.
+    positions_df:
+        Source positions table with ``PositionID`` and ``Position`` columns.
+    etl_version:
+        Version tag written to the ``etl_version`` column for lineage tracking.
+
+    Returns
+    -------
+    (behavior_df, report_dict)
+        ``behavior_df`` has one row per (season_year, owner_id) with all feature columns.
+        ``report_dict`` is a JSON-serialisable summary for gate evidence.
+    """
+    # ------------------------------------------------------------------ #
+    # 1. Build position ID → abbreviation lookup                          #
+    # ------------------------------------------------------------------ #
+    pos_lookup: dict[int, str] = {}
+    if not positions_df.empty and "PositionID" in positions_df.columns and "Position" in positions_df.columns:
+        for _, row in positions_df.iterrows():
+            pid = _parse_int(row.get("PositionID"))
+            abbr = str(row.get("Position", "")).strip()
+            if pid is not None and abbr:
+                pos_lookup[pid] = abbr
+
+    # ------------------------------------------------------------------ #
+    # 2. Enrich draft results with position abbreviation                  #
+    # ------------------------------------------------------------------ #
+    dr = draft_results_df.copy()
+    dr["owner_id"] = pd.to_numeric(dr.get("OwnerID"), errors="coerce")
+    dr["season_year"] = pd.to_numeric(dr.get("Year"), errors="coerce")
+    dr["winning_bid"] = dr.get("WinningBid", pd.Series(dtype=float)).apply(_parse_dollars)
+    dr["position_id_raw"] = pd.to_numeric(dr.get("PositionID"), errors="coerce")
+    dr = dr.dropna(subset=["owner_id", "season_year", "winning_bid"]).copy()
+    dr["owner_id"] = dr["owner_id"].astype(int)
+    dr["season_year"] = dr["season_year"].astype(int)
+    dr["position_id"] = dr["position_id_raw"].apply(
+        lambda v: _parse_int(v) if not pd.isna(v) else None
+    )
+    dr["position_abbr"] = dr["position_id"].map(lambda pid: pos_lookup.get(pid, "UNKNOWN") if pid else "UNKNOWN")
+
+    # ------------------------------------------------------------------ #
+    # 3. Build owner-season budget summary from timeline_df               #
+    # ------------------------------------------------------------------ #
+    budget_summary: dict[tuple[int, int], dict[str, Any]] = {}
+    if not timeline_df.empty:
+        for (season_year, owner_id), grp in timeline_df.groupby(["season_year", "owner_id"]):
+            last_row = grp.sort_values("event_sequence").iloc[-1]
+            budget_summary[(int(season_year), int(owner_id))] = {
+                "starting_budget": float(last_row["starting_budget"]) if not pd.isna(last_row["starting_budget"]) else None,
+                "total_spend": float(last_row["cumulative_spend"]) if not pd.isna(last_row["cumulative_spend"]) else None,
+                "remaining_budget": float(last_row["remaining_budget"]) if not pd.isna(last_row["remaining_budget"]) else None,
+                "budget_source": str(last_row.get("budget_source", "")),
+                "overspent": bool(last_row.get("overspent", False)),
+            }
+
+    # ------------------------------------------------------------------ #
+    # 4. Compute league-average positional spend % per season             #
+    # ------------------------------------------------------------------ #
+    league_avg_pct: dict[int, dict[str, float]] = {}
+    for season_year, season_grp in dr.groupby("season_year"):
+        total_season_spend = float(season_grp["winning_bid"].sum())
+        if total_season_spend <= 0:
+            continue
+        pos_totals = season_grp.groupby("position_abbr")["winning_bid"].sum()
+        league_avg_pct[int(season_year)] = {
+            pos: round(float(spend) / total_season_spend, 6)
+            for pos, spend in pos_totals.items()
+        }
+
+    # ------------------------------------------------------------------ #
+    # 5. Build per-owner-season feature rows                              #
+    # ------------------------------------------------------------------ #
+    feature_rows: list[dict[str, Any]] = []
+    null_rate_tracker: dict[str, int] = {
+        "aggressiveness_index": 0,
+        "positional_bias_index": 0,
+        "starting_budget": 0,
+    }
+    total_pairs = 0
+
+    for (season_year, owner_id), owner_grp in dr.groupby(["season_year", "owner_id"]):
+        total_pairs += 1
+        season_year = int(season_year)
+        owner_id = int(owner_id)
+
+        bids = owner_grp["winning_bid"].dropna().values
+        positions = owner_grp["position_abbr"].values
+        total_spend = float(sum(bids)) if len(bids) > 0 else 0.0
+
+        # Per-position breakdown
+        pos_spend: dict[str, float] = {}
+        pos_count: dict[str, int] = {}
+        pos_max: dict[str, float] = {}
+        pos_sum: dict[str, float] = {}
+        for bid, pos in zip(bids, positions):
+            pos_spend[pos] = pos_spend.get(pos, 0.0) + float(bid)
+            pos_count[pos] = pos_count.get(pos, 0) + 1
+            pos_max[pos] = max(pos_max.get(pos, 0.0), float(bid))
+            pos_sum[pos] = pos_sum.get(pos, 0.0) + float(bid)
+
+        pos_pct = {
+            pos: round(spend / total_spend, 6) if total_spend > 0 else 0.0
+            for pos, spend in pos_spend.items()
+        }
+        avg_bid = {
+            pos: round(pos_sum[pos] / pos_count[pos], 4) if pos_count[pos] > 0 else 0.0
+            for pos in pos_count
+        }
+
+        # Aggressiveness index: spend in top-quartile bids / total spend
+        agg_index: float | None = None
+        if len(bids) >= 1:
+            sorted_bids = sorted(bids, reverse=True)
+            top_n = max(1, len(sorted_bids) // 4)
+            agg_index = round(float(sum(sorted_bids[:top_n])) / total_spend, 6) if total_spend > 0 else None
+        if agg_index is None:
+            null_rate_tracker["aggressiveness_index"] += 1
+
+        # Positional bias index: mean absolute deviation from league-avg position %
+        pbias: float | None = None
+        league_avgs = league_avg_pct.get(season_year, {})
+        if league_avgs and pos_pct:
+            all_positions = set(league_avgs.keys()) | set(pos_pct.keys())
+            deviations = [abs(pos_pct.get(p, 0.0) - league_avgs.get(p, 0.0)) for p in all_positions]
+            pbias = round(float(sum(deviations)) / len(deviations), 6) if deviations else None
+        if pbias is None:
+            null_rate_tracker["positional_bias_index"] += 1
+
+        budget_row = budget_summary.get((season_year, owner_id), {})
+        if not budget_row.get("starting_budget"):
+            null_rate_tracker["starting_budget"] += 1
+
+        feature_rows.append({
+            "season_year": season_year,
+            "owner_id": owner_id,
+            "starting_budget": budget_row.get("starting_budget"),
+            "total_spend": round(total_spend, 2),
+            "remaining_budget": budget_row.get("remaining_budget"),
+            "budget_source": budget_row.get("budget_source"),
+            "overspent": budget_row.get("overspent"),
+            "spend_by_position": {k: round(v, 2) for k, v in pos_spend.items()},
+            "pick_count_by_position": pos_count,
+            "position_spend_pct": pos_pct,
+            "max_bid_by_position": {k: round(v, 2) for k, v in pos_max.items()},
+            "avg_bid_by_position": avg_bid,
+            "aggressiveness_index": agg_index,
+            "positional_bias_index": pbias,
+            "etl_version": etl_version,
+        })
+
+    behavior_df = pd.DataFrame(feature_rows).sort_values(
+        by=["season_year", "owner_id"], kind="mergesort"
+    ).reset_index(drop=True) if feature_rows else pd.DataFrame()
+
+    null_rates = {
+        key: round(count / total_pairs, 4) if total_pairs > 0 else None
+        for key, count in null_rate_tracker.items()
+    }
+
+    report = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "etl_version": etl_version,
+        "owner_season_pairs": total_pairs,
+        "behavior_rows": len(feature_rows),
+        "null_rates": null_rates,
+        "league_seasons_with_position_data": len(league_avg_pct),
+        "positions_seen": sorted({p for grp in league_avg_pct.values() for p in grp}),
+    }
+
+    return behavior_df, report
+
+
+def write_behavior_feature_outputs_from_dataframes(
+    *,
+    draft_budget_df: pd.DataFrame,
+    draft_results_df: pd.DataFrame,
+    users_df: pd.DataFrame,
+    positions_df: pd.DataFrame,
+    output_dir: Path,
+    etl_version: str = "v1",
+) -> dict[str, Any]:
+    """Build budget timeline + behavior features and write all outputs to ``output_dir``."""
+    timeline_df, _timeline_report = build_owner_budget_timeline(
+        draft_budget_df, draft_results_df, users_df
+    )
+    behavior_df, behavior_report = build_owner_behavior_features(
+        timeline_df, draft_results_df, positions_df, etl_version=etl_version
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    behavior_csv = output_dir / f"owner_behavior_features_{etl_version}.csv"
+    behavior_report_path = output_dir / f"owner_behavior_report_{etl_version}.json"
+
+    behavior_df.to_csv(behavior_csv, index=False)
+    behavior_report_path.write_text(json.dumps(behavior_report, indent=2), encoding="utf-8")
+
+    return {
+        "behavior_csv": str(behavior_csv),
+        "behavior_report": str(behavior_report_path),
+        "rows": int(len(behavior_df)),
+        "null_rates": behavior_report.get("null_rates", {}),
+    }
+
+
 def write_budget_timeline_outputs(
     draft_budget_csv: Path,
     draft_results_csv: Path,


### PR DESCRIPTION
## Summary

Advances #104 (Owner Budget Cleanup & Behavior Modeling Preparation). Tracked under parent #362.

---

### 1. `OwnerSeasonBehavior` ORM model

New `owner_season_behaviors` table in `backend/models.py`:

- **Budget reconciliation fields**: `starting_budget`, `total_spend`, `remaining_budget`, `budget_source` (exact / carry_forward / carry_backward / global_default), `overspent`
- **Positional breakdown** (JSON, keyed by position abbreviation): `spend_by_position`, `pick_count_by_position`, `position_spend_pct`, `max_bid_by_position`, `avg_bid_by_position`
- **Scalar behavioral indices**:
  - `aggressiveness_index` — fraction of total spend concentrated in the owner's top-quartile bids (0–1; higher = more aggressive on premium picks)
  - `positional_bias_index` — mean absolute deviation of owner's positional spend % from the league-average for that season (0 = perfectly average, higher = more skewed)
- `etl_version` for lineage; `UniqueConstraint(league_id, owner_id, season_year)`

### 2. Migration `0023`

`db/migrations/0023_add_owner_season_behavior_table.py` — idempotent. Depends on migration `0022` (PR #450, in review). Apply after that PR merges.

### 3. `build_owner_behavior_features()` ETL function

Added to `etl/transform/owner_budget_timeline.py`:

- Resolves `PositionID → abbreviation` from the positions table
- Per owner-year: computes all positional breakdowns, aggressiveness index, and positional bias index
- Anti-leakage: all features are computed purely from within-season data
- Emits a JSON gate report with `null_rates`, `positions_seen`, and `owner_season_pairs`

Also adds `write_behavior_feature_outputs_from_dataframes()` which writes:
- `etl/outputs/owner_budget/owner_behavior_features_v1.csv`
- `etl/outputs/owner_budget/owner_behavior_report_v1.json`

### 4. `build_phase1_artifacts.py` wired

The behavior feature step is now called automatically when the phase 1 artifact pipeline runs. Output is included in the manifest under `362_owner_behavior_features`.

### 5. Gate evidence (tests)

7 new tests in `etl/test_phase1_artifacts.py` (10 total, all passing):

| Test | Validates |
|---|---|
| `returns_one_row_per_owner_season` | Correct cardinality |
| `positional_spend_sums_to_total` | Internal arithmetic |
| `position_spend_pct_sums_to_one` | Percentage normalisation |
| `aggressiveness_index_between_0_and_1` | Index bounds + correct value (0.5 for 3-pick owner w/ $100/$200 top pick) |
| `positional_bias_index_non_negative` | Index bounds |
| `empty_input_returns_empty_df` | Graceful handling of missing data |
| `is_idempotent` | Byte-equivalent output on identical input |

```
.venv/bin/pytest etl/test_phase1_artifacts.py -v
# 10 passed in 0.94s
```

---

## Follow-up (not in scope)

- DB write-back: populate `owner_season_behaviors` from the ETL output (same pattern as #451 for canonical snapshots)
- Consume `OwnerSeasonBehavior` rows in ML feature engineering (#106)

## Data quality note

The current source data only has 2024 budget entries; 71 of 96 owner-seasons used `carry_backward` imputation. This is noted in `budget_timeline_report_v1.json`. Historical budget entry is a manual data enrichment task outside this PR's scope.
