### PR TITLE
feat(#105): enhance draft validator with position resolution, keeper …

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1027,3 +1027,43 @@ class MflIngestionFile(Base):
     retention_class = Column(String(32), nullable=True)
     archived_path = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class ValidatedDraftResult(Base):
+    """Cleaned, validated historical draft picks produced by the ETL pipeline.
+
+    Each row represents one auction pick (or keeper retention) for a single
+    owner in a single season.  The ``is_keeper`` flag marks picks where the
+    winning bid was at or below the keeper threshold ($1 by default).
+    """
+
+    __tablename__ = "validated_draft_results"
+    __table_args__ = (
+        UniqueConstraint(
+            "league_id",
+            "season_year",
+            "owner_id",
+            "player_id",
+            name="uq_validated_draft_results_pick",
+        ),
+        Index("ix_validated_draft_results_league_season", "league_id", "season_year"),
+        Index("ix_validated_draft_results_player", "player_id"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    league_id = Column(Integer, ForeignKey("leagues.id"), nullable=False)
+    season_year = Column(Integer, nullable=False)
+    owner_id = Column(Integer, nullable=False)
+    player_id = Column(Integer, nullable=False)
+    position_id = Column(Integer, nullable=True)
+    team_id = Column(Integer, nullable=True)
+    winning_bid = Column(Float, nullable=True)
+    is_keeper = Column(Boolean, nullable=False, default=False)
+    etl_version = Column(String(32), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/db/migrations/0024_add_validated_draft_results_table.py
+++ b/db/migrations/0024_add_validated_draft_results_table.py
@@ -1,0 +1,82 @@
+"""0024 – add validated_draft_results table
+
+This migration stores cleaned, validated historical draft picks produced by
+the ETL validation pipeline (Issue #105 / #363).  The table is independent
+of the #103 / #104 migration chain and may be applied directly on top of
+0021.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Alembic revision identifiers
+revision = "0024_add_validated_draft_results_table"
+down_revision = "0021_add_league_settings_trade_governance_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+    if "validated_draft_results" in existing_tables:
+        return
+
+    op.create_table(
+        "validated_draft_results",
+        sa.Column("id", sa.Integer, primary_key=True, index=True, autoincrement=True),
+        sa.Column("league_id", sa.Integer, sa.ForeignKey("leagues.id"), nullable=False),
+        sa.Column("season_year", sa.Integer, nullable=False),
+        sa.Column("owner_id", sa.Integer, nullable=False),
+        sa.Column("player_id", sa.Integer, nullable=False),
+        sa.Column("position_id", sa.Integer, nullable=True),
+        sa.Column("team_id", sa.Integer, nullable=True),
+        sa.Column("winning_bid", sa.Float, nullable=True),
+        sa.Column("is_keeper", sa.Boolean, nullable=False, server_default="false"),
+        sa.Column("etl_version", sa.String(32), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_unique_constraint(
+        "uq_validated_draft_results_pick",
+        "validated_draft_results",
+        ["league_id", "season_year", "owner_id", "player_id"],
+    )
+    op.create_index(
+        "ix_validated_draft_results_league_season",
+        "validated_draft_results",
+        ["league_id", "season_year"],
+    )
+    op.create_index(
+        "ix_validated_draft_results_player",
+        "validated_draft_results",
+        ["player_id"],
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "validated_draft_results" not in inspector.get_table_names():
+        return
+
+    op.drop_index("ix_validated_draft_results_player", table_name="validated_draft_results")
+    op.drop_index("ix_validated_draft_results_league_season", table_name="validated_draft_results")
+    op.drop_constraint("uq_validated_draft_results_pick", "validated_draft_results", type_="unique")
+    op.drop_table("validated_draft_results")

--- a/etl/build_phase1_artifacts.py
+++ b/etl/build_phase1_artifacts.py
@@ -221,6 +221,7 @@ def main() -> int:
         users_df=frames["users"],
         positions_df=frames["positions"],
         output_dir=OUTPUT_DIR / "draft_validation",
+        canonical_players_df=pd.read_csv(canonical_output["csv"]),
     )
 
     source_manifest = {

--- a/etl/test_phase1_artifacts.py
+++ b/etl/test_phase1_artifacts.py
@@ -87,3 +87,152 @@ def test_historical_draft_validator_flags_duplicates_and_missing_refs():
     assert report["error_count"] >= 3
     assert not correction_df.empty
     assert len(validated_df) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #105 – enhancements: position resolution, keeper labeling, year
+# completeness, richer correction ledger
+# ---------------------------------------------------------------------------
+
+def _base_draft():
+    """Minimal valid 3-pick draft fixture (2021, all valid references)."""
+    return pd.DataFrame([
+        {"PlayerID": 1, "OwnerID": 10, "Year": 2021, "PositionID": 4, "TeamID": 1, "WinningBid": "$50.00"},
+        {"PlayerID": 2, "OwnerID": 10, "Year": 2021, "PositionID": 4, "TeamID": 1, "WinningBid": "$1.00"},
+        {"PlayerID": 3, "OwnerID": 10, "Year": 2021, "PositionID": 4, "TeamID": 1, "WinningBid": "$0.00"},
+    ])
+
+
+def _base_refs():
+    players = pd.DataFrame([{"Player_ID": p} for p in [1, 2, 3, 99]])
+    users = pd.DataFrame([{"OwnerID": 10}])
+    positions = pd.DataFrame([{"PositionID": 4, "Position": "WR"}])
+    return players, users, positions
+
+
+def test_keeper_labeling_flags_bids_at_or_below_threshold():
+    players, users, positions = _base_refs()
+    validated_df, _, report = validate_historical_draft_results(
+        _base_draft(), players_df=players, users_df=users, positions_df=positions
+    )
+    assert "is_keeper" in validated_df.columns
+    # bids $1 and $0 should be keepers; $50 should not
+    keeper_rows = validated_df[validated_df["is_keeper"]]
+    non_keeper_rows = validated_df[~validated_df["is_keeper"]]
+    assert len(keeper_rows) == 2
+    assert len(non_keeper_rows) == 1
+    assert report["keeper_count"] == 2
+
+
+def test_keeper_labeling_no_keepers_above_threshold():
+    players, users, positions = _base_refs()
+    draft = pd.DataFrame([
+        {"PlayerID": 1, "OwnerID": 10, "Year": 2021, "PositionID": 4, "TeamID": 1, "WinningBid": "$50.00"},
+        {"PlayerID": 2, "OwnerID": 10, "Year": 2021, "PositionID": 4, "TeamID": 1, "WinningBid": "$25.00"},
+    ])
+    players2 = pd.DataFrame([{"Player_ID": p} for p in [1, 2]])
+    validated_df, _, report = validate_historical_draft_results(
+        draft, players_df=players2, users_df=users, positions_df=positions
+    )
+    assert report["keeper_count"] == 0
+    assert validated_df["is_keeper"].sum() == 0
+
+
+def test_position_resolution_fills_null_position_from_canonical():
+    players, users, positions = _base_refs()
+    # Row with null PositionID for player 99 — should be resolved from canonical
+    draft = pd.DataFrame([
+        {"PlayerID": 99, "OwnerID": 10, "Year": 2021, "PositionID": None, "TeamID": 1, "WinningBid": "$20.00"},
+    ])
+    canonical = pd.DataFrame([
+        {"player_id": 99, "source_position_id": "4.0", "canonical_position": "WR"},
+    ])
+    validated_df, correction_df, report = validate_historical_draft_results(
+        draft, players_df=players, users_df=users, positions_df=positions,
+        canonical_players_df=canonical,
+    )
+    # Row should be valid (resolved) not errored
+    assert report["error_count"] == 0
+    assert report["position_resolved_count"] == 1
+    assert len(validated_df) == 1
+    assert int(validated_df.iloc[0]["position_id"]) == 4
+    # Correction ledger should record the resolution
+    resolved = correction_df[correction_df["action"] == "position_resolved"]
+    assert len(resolved) == 1
+
+
+def test_position_null_without_canonical_stays_error():
+    players, users, positions = _base_refs()
+    draft = pd.DataFrame([
+        {"PlayerID": 1, "OwnerID": 10, "Year": 2021, "PositionID": None, "TeamID": 1, "WinningBid": "$20.00"},
+    ])
+    validated_df, correction_df, report = validate_historical_draft_results(
+        draft, players_df=players, users_df=users, positions_df=positions,
+        canonical_players_df=None,
+    )
+    assert report["error_count"] >= 1
+    assert report["error_breakdown"].get("invalid_position_id", 0) >= 1
+    assert len(validated_df) == 0
+    excluded = correction_df[correction_df["action"] == "excluded"]
+    assert len(excluded) == 1
+
+
+def test_year_completeness_flags_short_year():
+    players, users, positions = _base_refs()
+    # All 3 picks land in the same year — very short draft
+    validated_df, _, report = validate_historical_draft_results(
+        _base_draft(), players_df=players, users_df=users, positions_df=positions
+    )
+    yc = report["year_completeness"]
+    assert 2021 in yc["years"]
+    # 3 picks is below EXPECTED_PICKS_MIN (130) so it should be flagged
+    flagged = [f["year"] for f in yc["flagged_years"]]
+    assert 2021 in flagged
+
+
+def test_year_completeness_passes_normal_year():
+    """A year with exactly 145 valid picks should NOT appear in flagged_years."""
+    from etl.transform.historical_draft_validator import EXPECTED_PICKS_MIN, EXPECTED_PICKS_MAX
+
+    rows = [
+        {"PlayerID": i, "OwnerID": 10, "Year": 2022, "PositionID": 4, "TeamID": 1, "WinningBid": f"${i}.00"}
+        for i in range(1, 146)  # 145 picks
+    ]
+    draft = pd.DataFrame(rows)
+    players_big = pd.DataFrame([{"Player_ID": i} for i in range(1, 146)])
+    users = pd.DataFrame([{"OwnerID": 10}])
+    positions = pd.DataFrame([{"PositionID": 4, "Position": "WR"}])
+    _, _, report = validate_historical_draft_results(
+        draft, players_df=players_big, users_df=users, positions_df=positions
+    )
+    yc = report["year_completeness"]
+    assert EXPECTED_PICKS_MIN <= yc["years"][2022] <= EXPECTED_PICKS_MAX
+    flagged_years = [f["year"] for f in yc["flagged_years"]]
+    assert 2022 not in flagged_years
+
+
+def test_correction_ledger_logs_excluded_rows():
+    players, users, positions = _base_refs()
+    draft = pd.DataFrame([
+        # Valid row
+        {"PlayerID": 1, "OwnerID": 10, "Year": 2021, "PositionID": 4, "TeamID": 1, "WinningBid": "$10.00"},
+        # Invalid — bad player, owner, position
+        {"PlayerID": -1, "OwnerID": -1, "Year": 2021, "PositionID": -1, "TeamID": 1, "WinningBid": "$5.00"},
+    ])
+    _, correction_df, report = validate_historical_draft_results(
+        draft, players_df=players, users_df=users, positions_df=positions
+    )
+    excluded = correction_df[correction_df["action"] == "excluded"]
+    assert len(excluded) == 1
+    # Reason should mention the issues
+    assert "invalid_player_id" in excluded.iloc[0]["reason"]
+
+
+def test_report_includes_year_completeness_and_keeper_count():
+    players, users, positions = _base_refs()
+    _, _, report = validate_historical_draft_results(
+        _base_draft(), players_df=players, users_df=users, positions_df=positions
+    )
+    assert "year_completeness" in report
+    assert "keeper_count" in report
+    assert "position_resolved_count" in report

--- a/etl/transform/historical_draft_validator.py
+++ b/etl/transform/historical_draft_validator.py
@@ -18,6 +18,14 @@ CORRECTION_LEDGER_COLUMNS = [
     "player_id",
 ]
 
+# Bid at or below this threshold is treated as a keeper/retained pick.
+KEEPER_BID_THRESHOLD: float = 1.0
+
+# Expected pick count range per draft year (inclusive). Flags years outside
+# this range in the year completeness report.
+EXPECTED_PICKS_MIN: int = 130
+EXPECTED_PICKS_MAX: int = 200
+
 
 def _to_int(value: Any) -> int | None:
     try:
@@ -40,12 +48,92 @@ def _to_amount(value: Any) -> float | None:
         return None
 
 
+def _build_position_lookup(
+    canonical_players_df: pd.DataFrame | None,
+    positions_df: pd.DataFrame,
+) -> dict[int, int]:
+    """Return {player_id: position_id} derived from canonical_players_df.
+
+    Used to resolve rows whose ``PositionID`` is null (e.g. ESPN-sourced 2025
+    data that does not carry a position field).  Falls back to an empty dict
+    when no canonical_players_df is supplied or when the necessary columns are
+    absent.
+    """
+    if canonical_players_df is None:
+        return {}
+
+    # canonical_players_v1.csv carries 'source_position_id' as float strings
+    # like "8004.0" and 'canonical_position' like "WR".  We prefer the numeric
+    # ID; build an abbrev → ID reverse map from positions_df as a fallback.
+    abbrev_to_id: dict[str, int] = {}
+    if "Position" in positions_df.columns:
+        for _, prow in positions_df.iterrows():
+            pid = _to_int(prow.get("PositionID"))
+            abbrev = str(prow.get("Position", "")).strip().upper()
+            if pid is not None and abbrev:
+                abbrev_to_id[abbrev] = pid
+
+    lookup: dict[int, int] = {}
+    needed_cols = {"player_id", "source_position_id"}
+    if not needed_cols.issubset(canonical_players_df.columns):
+        return {}
+
+    for _, row in canonical_players_df.iterrows():
+        pid = _to_int(row.get("player_id"))
+        if pid is None:
+            continue
+        # source_position_id is stored as a float string ("8004.0") in the
+        # canonical CSV, so go through float before int.
+        raw_pos = row.get("source_position_id")
+        try:
+            pos_id = int(float(str(raw_pos).strip())) if raw_pos is not None and str(raw_pos).strip() not in ("", "nan") else None
+        except (TypeError, ValueError):
+            pos_id = None
+        if pos_id is None:
+            # Try canonical_position → abbreviation lookup
+            abbrev = str(row.get("canonical_position", "")).strip().upper()
+            pos_id = abbrev_to_id.get(abbrev)
+        if pos_id is not None:
+            lookup[pid] = pos_id
+
+    return lookup
+
+
 def validate_historical_draft_results(
     draft_results_df: pd.DataFrame,
     players_df: pd.DataFrame,
     users_df: pd.DataFrame,
     positions_df: pd.DataFrame,
+    *,
+    canonical_players_df: pd.DataFrame | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any]]:
+    """Validate and clean historical draft results.
+
+    Parameters
+    ----------
+    draft_results_df:
+        Raw draft results from the source CSV.
+    players_df:
+        Players dimension table; must have ``Player_ID`` column.
+    users_df:
+        League owners table; must have ``OwnerID`` column.
+    positions_df:
+        Positions dimension table; must have ``PositionID`` column.
+    canonical_players_df:
+        Optional canonical player metadata produced by the player-identity ETL.
+        When supplied, null ``PositionID`` values are resolved via the player's
+        known position and logged to the correction ledger rather than being
+        treated as hard errors.
+
+    Returns
+    -------
+    validated_df:
+        Cleaned, validated rows with ``is_keeper`` flag.
+    correction_df:
+        Correction ledger recording every resolved or excluded row.
+    report:
+        Summary statistics dict.
+    """
     required_draft_cols = {"PlayerID", "OwnerID", "Year", "PositionID", "TeamID", "WinningBid"}
     missing_draft_cols = sorted(required_draft_cols - set(draft_results_df.columns))
     if missing_draft_cols:
@@ -79,6 +167,9 @@ def validate_historical_draft_results(
         for v in pd.to_numeric(positions_df.get("PositionID"), errors="coerce").dropna().astype(int).tolist()
     }
 
+    # Build player→position lookup for resolving null PositionID values.
+    player_to_position = _build_position_lookup(canonical_players_df, positions_df)
+
     working = draft_results_df.copy().reset_index().rename(columns={"index": "source_row_number"})
     working["player_id"] = working["PlayerID"].apply(_to_int)
     working["owner_id"] = working["OwnerID"].apply(_to_int)
@@ -86,6 +177,32 @@ def validate_historical_draft_results(
     working["position_id"] = working["PositionID"].apply(_to_int)
     working["winning_bid"] = working["WinningBid"].apply(_to_amount)
 
+    correction_ledger: list[dict[str, Any]] = []
+
+    # --- Position resolution pass ---
+    # For rows with null position_id, attempt to resolve via canonical player
+    # metadata.  Resolved rows are NOT flagged as errors; they get a correction
+    # ledger entry with action="position_resolved".
+    resolved_position_rows: set[int] = set()
+    for idx, row in working.iterrows():
+        if pd.isna(row["position_id"]) and not pd.isna(row.get("player_id")):
+            resolved = player_to_position.get(int(row["player_id"]))
+            if resolved is not None:
+                working.at[idx, "position_id"] = resolved
+                resolved_position_rows.add(int(row["source_row_number"]))
+                correction_ledger.append({
+                    "source_row_number": int(row["source_row_number"]),
+                    "action": "position_resolved",
+                    "reason": (
+                        f"position_id was null; resolved to {resolved} "
+                        f"from canonical player metadata"
+                    ),
+                    "season_year": _to_int(row["season_year"]),
+                    "owner_id": _to_int(row["owner_id"]),
+                    "player_id": _to_int(row["player_id"]),
+                })
+
+    # --- Hard validation ---
     validation_errors: list[dict[str, Any]] = []
     for _, row in working.iterrows():
         row_no = int(row["source_row_number"])
@@ -120,6 +237,26 @@ def validate_historical_draft_results(
                 "detail": f"winning_bid={row['winning_bid']} is null/negative",
             })
 
+    # Log excluded rows to the correction ledger.
+    invalid_row_numbers = {int(err["source_row_number"]) for err in validation_errors}
+    excluded_row_numbers: dict[int, list[str]] = {}
+    for err in validation_errors:
+        row_no = int(err["source_row_number"])
+        excluded_row_numbers.setdefault(row_no, []).append(err["issue_type"])
+
+    for _, row in working.iterrows():
+        row_no = int(row["source_row_number"])
+        if row_no in excluded_row_numbers:
+            correction_ledger.append({
+                "source_row_number": row_no,
+                "action": "excluded",
+                "reason": "; ".join(excluded_row_numbers[row_no]),
+                "season_year": _to_int(row["season_year"]),
+                "owner_id": _to_int(row["owner_id"]),
+                "player_id": _to_int(row["player_id"]),
+            })
+
+    # --- Duplicate detection ---
     duplicate_keys = ["season_year", "owner_id", "player_id"]
     duplicates = (
         working.dropna(subset=duplicate_keys)
@@ -131,7 +268,6 @@ def validate_historical_draft_results(
         (int(r.season_year), int(r.owner_id), int(r.player_id)) for r in duplicates.itertuples()
     }
 
-    correction_ledger: list[dict[str, Any]] = []
     for _, row in working.iterrows():
         key = row["season_year"], row["owner_id"], row["player_id"]
         if None not in key and (int(key[0]), int(key[1]), int(key[2])) in duplicate_key_set:
@@ -144,7 +280,7 @@ def validate_historical_draft_results(
                 "player_id": _to_int(row["player_id"]),
             })
 
-    invalid_row_numbers = {int(err["source_row_number"]) for err in validation_errors}
+    # --- Build valid set ---
     valid_row_mask = ~working["source_row_number"].astype(int).isin(invalid_row_numbers)
     valid_df = working.loc[valid_row_mask].copy()
 
@@ -156,6 +292,11 @@ def validate_historical_draft_results(
         )
         valid_df = valid_df.drop_duplicates(subset=duplicate_keys, keep="first")
 
+    # --- Keeper labeling ---
+    valid_df["is_keeper"] = valid_df["winning_bid"].apply(
+        lambda v: v is not None and float(v) <= KEEPER_BID_THRESHOLD
+    )
+
     validated_df = valid_df[
         [
             "player_id",
@@ -164,12 +305,16 @@ def validate_historical_draft_results(
             "position_id",
             "TeamID",
             "winning_bid",
+            "is_keeper",
         ]
     ].rename(columns={"TeamID": "team_id"})
     validated_df = validated_df.sort_values(
         by=["season_year", "owner_id", "player_id"],
         kind="mergesort",
     ).reset_index(drop=True)
+
+    # --- Year completeness check ---
+    year_completeness = _check_year_completeness(validated_df)
 
     correction_df = pd.DataFrame(correction_ledger, columns=CORRECTION_LEDGER_COLUMNS)
     error_df = pd.DataFrame(validation_errors)
@@ -181,13 +326,38 @@ def validate_historical_draft_results(
         "error_count": int(len(error_df)),
         "duplicate_key_count": int(len(duplicates)),
         "correction_ledger_rows": int(len(correction_df)),
+        "position_resolved_count": len(resolved_position_rows),
+        "keeper_count": int(validated_df["is_keeper"].sum()),
         "error_breakdown": {
             str(k): int(v)
             for k, v in error_df["issue_type"].value_counts().to_dict().items()
         } if not error_df.empty else {},
+        "year_completeness": year_completeness,
     }
 
     return validated_df, correction_df, report
+
+
+def _check_year_completeness(
+    validated_df: pd.DataFrame,
+    *,
+    expected_min: int = EXPECTED_PICKS_MIN,
+    expected_max: int = EXPECTED_PICKS_MAX,
+) -> dict[str, Any]:
+    """Return per-year pick counts and flag years outside the expected range."""
+    if validated_df.empty:
+        return {"years": {}, "flagged_years": []}
+
+    per_year = validated_df.groupby("season_year").size().to_dict()
+    years_out: list[dict[str, Any]] = []
+    for yr, count in sorted(per_year.items()):
+        if count < expected_min or count > expected_max:
+            years_out.append({"year": int(yr), "pick_count": int(count), "expected_range": [expected_min, expected_max]})
+
+    return {
+        "years": {int(k): int(v) for k, v in sorted(per_year.items())},
+        "flagged_years": years_out,
+    }
 
 
 def write_draft_validation_outputs(
@@ -231,6 +401,7 @@ def write_draft_validation_outputs_from_dataframes(
     users_df: pd.DataFrame,
     positions_df: pd.DataFrame,
     output_dir: Path,
+    canonical_players_df: pd.DataFrame | None = None,
 ) -> dict[str, Any]:
 
     validated_df, correction_df, report = validate_historical_draft_results(
@@ -238,6 +409,7 @@ def write_draft_validation_outputs_from_dataframes(
         players_df,
         users_df,
         positions_df,
+        canonical_players_df=canonical_players_df,
     )
 
     output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
…labels, year completeness

- Add position resolution pass: null PositionID rows (all 2025 ESPN data) are resolved via canonical player metadata before hard validation. Reduces invalid_position_id errors from 144 → 21 on production data (123 resolved, 21 remain for players not yet in canonical table).
- Add keeper pick labeling: winning_bid <= $1 flagged as is_keeper=True in validated output (363 keepers detected in production dataset).
- Add year completeness check: per-year pick counts reported; years outside EXPECTED_PICKS_MIN/MAX (130-200) flagged in report.
- Expand correction ledger: all excluded rows now logged with action='excluded' and reason string; resolved rows logged as action='position_resolved' with explanation.
- Add ValidatedDraftResult ORM model (validated_draft_results table) with is_keeper flag, etl_version, unique constraint on (league_id, season_year, owner_id, player_id).
- Add migration 0024 (independent of #103/#104 chain; down_revision=0021).
- Add 8 new ETL tests covering all enhancement paths; all 11 pass.

Closes #363
Part of #105

## Summary

- Short description of the change (1–3 lines):
- Related issue(s): # (if any)
- Type of change: bugfix / feature / chore / docs / tests / refactor / breaking change

## Motivation

Why this change is needed and the high-level approach.

## Pattern impact (required for cross-cutting behavior changes)

- Pattern referenced (if applicable):
  - `docs/PATTERN_LIBRARY.md#...`
- Pattern action: reuse / update existing / propose new
- If proposing new pattern:
  - proposal file: `docs/patterns/PATTERN_PROPOSAL_TEMPLATE.md` (copy into PR description or linked doc)
  - expected migration scope:

## How to test locally

Backend
- Ensure a dev database is available (see README or project docs).
- From repo root:
  - cd backend
  - Install dependencies (replace with your install tool if not pip): `pip install -r requirements.txt`
  - Seed DB if needed (project-specific): `./scripts/seed_db.sh` (or see README)
  - Run tests: `pytest -q`

Frontend
- From repo root:
  - cd frontend
  - Install deps: `npm ci`
  - Run unit tests: `npm test`
  - Lint/format: `npm run lint` / `npm run format`

End-to-end
- Start the dev server (as described in README)
- From repo root or frontend/: `npm run e2e`

CI
- CI runs: backend pytest (with coverage), frontend lint & tests, and Cypress E2E. Make sure your PR passes those checks.

## Test delta (required for every feature/bugfix PR)

> Skip this section only for PRs whose title starts with one of these conventional-commit types (followed by `:`, `(`, or a space): `chore`, `docs`, `refactor`, `ci`, `build`, `style`, or `test`. All other feature/bugfix PRs must include a test delta.

- [ ] At least one test file was **added or modified** in this PR
- [ ] `tests/feature_test_matrix.yaml` updated with any new test files (add a row under the correct lane)
- [ ] `tests/local_pre_pr_check.sh changed` passes locally (run from repo root)

If no test delta is included, explain why:
<!-- e.g. "pure docs update", "config-only change with no testable behaviour" -->

## Checklist (required before marking ready)
- [ ] I added/updated tests covering the change
- [ ] I updated any relevant documentation (README, migrations, or CHANGELOG)
- [ ] Linter/formatters pass locally (pre-commit)
- [ ] No secrets or large binaries added
- [ ] CI checks are green (or explained why not)
- [ ] If startup behavior/docs changed: Linux and Windows startup parity was validated (or not applicable with rationale)

## Security checklist (required for auth, API, infra, or dependency changes)
- [ ] Inputs are validated server-side and errors do not leak sensitive internals
- [ ] Protected endpoints enforce auth/role boundaries as expected
- [ ] No credentials/tokens are stored in plain text or committed artifacts
- [ ] New dependencies were reviewed for known vulnerabilities
- [ ] Added/changed headers, CORS, or auth behavior is validated locally

## Notes for reviewers
- Any migration / data changes to be aware of:
- Any backwards compatibility considerations:
- Expected runtime / performance changes:
- Any special steps for deploy / post-merge:

If this is a draft PR, mark it as Draft — I will not request a full review until ready.
