### PR TITLE
feat(auth): server-side JWT revocation with persistent jti blocklist (#405)

### DIFF
--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -2,6 +2,7 @@
 import os
 from datetime import datetime, timedelta, timezone # 1.1.1 Use timezone-aware datetime
 from typing import Optional
+from uuid import uuid4
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from fastapi import Depends, HTTPException, Request, status
@@ -34,6 +35,7 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
 ACCESS_TOKEN_COOKIE_NAME = os.environ.get("ACCESS_TOKEN_COOKIE_NAME", "ffpi_access_token")
 ALLOW_BEARER_AUTH = os.environ.get("ALLOW_BEARER_AUTH", "0") == "1"
+REVOCATION_PRUNE_INTERVAL_SECONDS = int(os.environ.get("REVOCATION_PRUNE_INTERVAL_SECONDS", "300"))
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 # 1.1.3 IMPORTANT: Point this to your new auth router path
@@ -45,6 +47,8 @@ credentials_exception = HTTPException(
     detail="Could not validate credentials",
     headers={"WWW-Authenticate": "Bearer"},
 )
+
+_last_revocation_prune_at: datetime | None = None
 
 # --- 1.2 UTILITY FUNCTIONS (THE TOOLS) ---
 def verify_password(plain_password, hashed_password):
@@ -86,8 +90,81 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     else:
         expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     
+    if not to_encode.get("jti"):
+        to_encode["jti"] = uuid4().hex
+
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def choose_auth_token(cookie_token: Optional[str], bearer_token: Optional[str]) -> Optional[str]:
+    candidate_bearer = bearer_token if ALLOW_BEARER_AUTH else None
+    return cookie_token or candidate_bearer
+
+
+def decode_access_token(auth_token: str) -> dict:
+    return jwt.decode(auth_token, SECRET_KEY, algorithms=[ALGORITHM])
+
+
+def prune_expired_revoked_tokens(db: Session, force: bool = False) -> int:
+    global _last_revocation_prune_at
+
+    now = datetime.now(timezone.utc)
+    if not force and _last_revocation_prune_at is not None:
+        elapsed = (now - _last_revocation_prune_at).total_seconds()
+        if elapsed < REVOCATION_PRUNE_INTERVAL_SECONDS:
+            return 0
+
+    deleted = (
+        db.query(models.RevokedToken)
+        .filter(models.RevokedToken.expires_at <= now)
+        .delete(synchronize_session=False)
+    )
+    _last_revocation_prune_at = now
+    if deleted:
+        db.commit()
+    return int(deleted)
+
+
+def is_token_revoked(db: Session, jti: Optional[str]) -> bool:
+    if not jti:
+        return False
+    return (
+        db.query(models.RevokedToken.id)
+        .filter(models.RevokedToken.jti == jti)
+        .first()
+        is not None
+    )
+
+
+def revoke_access_token(db: Session, auth_token: str) -> bool:
+    try:
+        payload = decode_access_token(auth_token)
+    except JWTError:
+        return False
+
+    jti = payload.get("jti")
+    exp = payload.get("exp")
+    subject = payload.get("sub")
+    if not jti or exp is None:
+        return False
+
+    expires_at = datetime.fromtimestamp(exp, tz=timezone.utc)
+    if expires_at <= datetime.now(timezone.utc):
+        return False
+
+    if is_token_revoked(db, jti):
+        return True
+
+    db.add(
+        models.RevokedToken(
+            jti=str(jti),
+            token_subject=str(subject) if subject is not None else None,
+            expires_at=expires_at,
+        )
+    )
+    db.commit()
+    return True
 
 # --- 2.1 THE BOUNCERS (REFACTORED) ---
 
@@ -100,17 +177,21 @@ async def get_current_user(
     db: Session = Depends(get_db),
 ):
     cookie_token = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME)
-    bearer_token = token if ALLOW_BEARER_AUTH else None
-    auth_token = cookie_token or bearer_token
+    auth_token = choose_auth_token(cookie_token, token)
     if not auth_token:
         raise credentials_exception
 
     try:
-        payload = jwt.decode(auth_token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = decode_access_token(auth_token)
         username: str = payload.get("sub")
-        if username is None:
+        jti: str | None = payload.get("jti")
+        if username is None or jti is None:
             raise credentials_exception
     except JWTError:
+        raise credentials_exception
+
+    prune_expired_revoked_tokens(db)
+    if is_token_revoked(db, jti):
         raise credentials_exception
 
     user = db.query(models.User).filter(models.User.username == username).first()

--- a/backend/models.py
+++ b/backend/models.py
@@ -41,6 +41,20 @@ class User(Base):
     scoring_rule_proposals = relationship("ScoringRuleProposal", foreign_keys="ScoringRuleProposal.proposed_by_user_id", back_populates="proposed_by_user")
     scoring_rule_votes = relationship("ScoringRuleVote", foreign_keys="ScoringRuleVote.voter_user_id", back_populates="voter_user")
 
+
+class RevokedToken(Base):
+    __tablename__ = "revoked_tokens"
+    __table_args__ = (
+        UniqueConstraint("jti", name="uq_revoked_tokens_jti"),
+        Index("ix_revoked_tokens_expires_at", "expires_at"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    jti = Column(String(64), nullable=False, index=True)
+    token_subject = Column(String(255), nullable=True)
+    revoked_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+
 # --- 2. LEAGUE TABLE ---
 class League(Base):
     __tablename__ = "leagues"

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -153,6 +153,7 @@ def login_for_access_token(
 
     _clear_failed_attempts(attempt_key)
     logger.info("Successful login user_id=%s username=%s ip=%s", user.id, user.username, client_ip)
+    security.prune_expired_revoked_tokens(db)
 
     # 2.2.1 TOKEN GEN: Create JWT Access Token
     access_token_expires = timedelta(minutes=security.ACCESS_TOKEN_EXPIRE_MINUTES)
@@ -176,7 +177,18 @@ def login_for_access_token(
 
 
 @router.post("/logout")
-def logout(response: Response):
+def logout(
+    request: Request,
+    response: Response,
+    token: str = Depends(security.oauth2_scheme),
+    db: Session = Depends(get_db),
+):
+    cookie_token = request.cookies.get(ACCESS_TOKEN_COOKIE_NAME)
+    auth_token = security.choose_auth_token(cookie_token, token)
+    if auth_token:
+        security.revoke_access_token(db, auth_token)
+        security.prune_expired_revoked_tokens(db)
+
     _clear_auth_cookies(response)
     return {"message": "Logged out"}
 

--- a/backend/routers/draft.py
+++ b/backend/routers/draft.py
@@ -12,7 +12,6 @@ import pandas as pd
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
-from jose import JWTError, jwt
 
 try:
     from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
@@ -98,17 +97,21 @@ def _parse_session_context(session_id: str) -> tuple[int | None, int | None]:
 
 def _get_websocket_user(websocket: WebSocket, db: Session):
     cookie_token = websocket.cookies.get(security.ACCESS_TOKEN_COOKIE_NAME)
-    bearer_token = websocket.query_params.get("token") if security.ALLOW_BEARER_AUTH else None
-    auth_token = cookie_token or bearer_token
+    bearer_token = websocket.query_params.get("token")
+    auth_token = security.choose_auth_token(cookie_token, bearer_token)
     if not auth_token:
         return None
 
     try:
-        payload = jwt.decode(auth_token, security.SECRET_KEY, algorithms=[security.ALGORITHM])
+        payload = security.decode_access_token(auth_token)
         username = payload.get("sub")
-        if not username:
+        jti = payload.get("jti")
+        if not username or not jti:
             return None
-    except JWTError:
+    except Exception:
+        return None
+
+    if security.is_token_revoked(db, jti):
         return None
 
     return db.query(models.User).filter(models.User.username == username).first()

--- a/backend/tests/test_auth_cookie_csrf.py
+++ b/backend/tests/test_auth_cookie_csrf.py
@@ -1,10 +1,13 @@
 import sys
 from pathlib import Path
+from contextlib import asynccontextmanager
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+from jose import jwt
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -132,3 +135,98 @@ def test_login_with_malformed_hash_returns_401_not_500(client, api_db):
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Incorrect username or password"
+
+
+def test_logout_revokes_token_and_blocks_reuse(client, api_db, monkeypatch):
+    monkeypatch.setattr(
+        security,
+        "verify_password",
+        lambda plain_password, hashed_password: plain_password == "secret"
+        and hashed_password == "test-hash",
+    )
+
+    user = models.User(
+        username="revocation-user",
+        email="revocation-user@test.com",
+        hashed_password="test-hash",
+        league_id=1,
+    )
+    api_db.add(user)
+    api_db.commit()
+
+    login = client.post(
+        "/auth/token",
+        data={"username": "revocation-user", "password": "secret"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code == 200
+
+    access_token = login.json()["access_token"]
+    csrf_token = login.cookies.get("ffpi_csrf_token")
+    assert csrf_token
+
+    logout = client.post("/auth/logout", headers={"X-CSRF-Token": csrf_token})
+    assert logout.status_code == 200
+
+    # Re-inject the previously issued token; revocation should block it.
+    client.cookies.set("ffpi_access_token", access_token)
+    blocked = client.get("/auth/me")
+    assert blocked.status_code == 401
+
+
+def test_revocation_survives_fresh_client_session(client, api_db, monkeypatch):
+    monkeypatch.setattr(
+        security,
+        "verify_password",
+        lambda plain_password, hashed_password: plain_password == "secret"
+        and hashed_password == "test-hash",
+    )
+
+    user = models.User(
+        username="revocation-persist-user",
+        email="revocation-persist-user@test.com",
+        hashed_password="test-hash",
+        league_id=1,
+    )
+    api_db.add(user)
+    api_db.commit()
+
+    login = client.post(
+        "/auth/token",
+        data={"username": "revocation-persist-user", "password": "secret"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code == 200
+
+    access_token = login.json()["access_token"]
+    payload = jwt.decode(
+        access_token,
+        security.SECRET_KEY,
+        algorithms=[security.ALGORITHM],
+        options={"verify_exp": False},
+    )
+    jti = payload.get("jti")
+    assert jti
+
+    csrf_token = login.cookies.get("ffpi_csrf_token")
+    assert csrf_token
+    logout = client.post("/auth/logout", headers={"X-CSRF-Token": csrf_token})
+    assert logout.status_code == 200
+
+    assert api_db.query(models.RevokedToken).filter(models.RevokedToken.jti == jti).first() is not None
+
+    # Simulate a fresh process/client using the same persisted database rows.
+    original = app.router.lifespan_context
+
+    @asynccontextmanager
+    async def noop_lifespan(_app):
+        yield
+
+    app.router.lifespan_context = noop_lifespan
+    try:
+        with TestClient(app) as fresh_client:
+            fresh_client.cookies.set("ffpi_access_token", access_token)
+            blocked = fresh_client.get("/auth/me")
+            assert blocked.status_code == 401
+    finally:
+        app.router.lifespan_context = original

--- a/backend/tests/test_core_security.py
+++ b/backend/tests/test_core_security.py
@@ -36,6 +36,7 @@ def test_create_access_token_and_decode():
     from jose import jwt
     payload = jwt.decode(token, security.SECRET_KEY, algorithms=[security.ALGORITHM], options={"verify_exp": False})
     assert payload.get("sub") == "alice"
+    assert payload.get("jti")
 
 
 def test_verify_password_with_unknown_hash_format_returns_false():

--- a/db/migrations/0025_add_revoked_tokens_table.py
+++ b/db/migrations/0025_add_revoked_tokens_table.py
@@ -1,0 +1,54 @@
+"""0025 - add revoked_tokens table for JWT jti revocation
+
+Adds persistent token revocation storage so logout/session invalidation survives
+process restarts.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0025_add_revoked_tokens_table"
+down_revision = "0024_add_validated_draft_results_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+    if "revoked_tokens" in existing_tables:
+        return
+
+    op.create_table(
+        "revoked_tokens",
+        sa.Column("id", sa.Integer, primary_key=True, index=True, autoincrement=True),
+        sa.Column("jti", sa.String(length=64), nullable=False),
+        sa.Column("token_subject", sa.String(length=255), nullable=True),
+        sa.Column(
+            "revoked_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_unique_constraint("uq_revoked_tokens_jti", "revoked_tokens", ["jti"])
+    op.create_index("ix_revoked_tokens_jti", "revoked_tokens", ["jti"])
+    op.create_index("ix_revoked_tokens_expires_at", "revoked_tokens", ["expires_at"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "revoked_tokens" not in inspector.get_table_names():
+        return
+
+    op.drop_index("ix_revoked_tokens_expires_at", table_name="revoked_tokens")
+    op.drop_index("ix_revoked_tokens_jti", table_name="revoked_tokens")
+    op.drop_constraint("uq_revoked_tokens_jti", "revoked_tokens", type_="unique")
+    op.drop_table("revoked_tokens")


### PR DESCRIPTION
Parent: #402

Implements issue #405 end-to-end: server-side JWT invalidation using a persistent `jti` blocklist.

## What Changed

- Added persistent revoked token model/table
  - ORM: `backend/models.py` (`RevokedToken`)
  - Migration: `db/migrations/0025_add_revoked_tokens_table.py`

- Added `jti` claim to issued access tokens
  - `backend/core/security.py` now generates a UUID `jti` for each token.

- Added revocation + pruning helpers
  - `revoke_access_token(...)`
  - `is_token_revoked(...)`
  - `prune_expired_revoked_tokens(...)`
  - Token parsing utilities reused by request and websocket auth.

- Enforced revocation checks during auth validation
  - `get_current_user(...)` now rejects revoked token `jti`s.
  - Draft websocket auth (`backend/routers/draft.py`) also rejects revoked token `jti`s.

- Recorded revocation on logout
  - `POST /auth/logout` now decodes current token and persists revocation entry before clearing cookies.

## Tests

- Updated `backend/tests/test_core_security.py`
  - Verifies JWT contains `jti`.

- Expanded `backend/tests/test_auth_cookie_csrf.py`
  - Verifies logout revokes token and reused token is blocked.
  - Verifies revocation survives fresh client session (persistent DB-backed revocation).

All targeted tests passed locally:
- `backend/tests/test_auth_cookie_csrf.py`
- `backend/tests/test_core_security.py`

## Acceptance Criteria Mapping

- Logged-out token can no longer access protected endpoints: ✅
- Revocation survives process restart: ✅ (DB-persisted + fresh client validation)
- Auth checks include revocation lookup: ✅
- Integration tests verify revoke-and-block behavior: ✅
