### PR TITLE
chore(ci): upgrade workflow action pins to current majors

### DIFF
--- a/.github/workflows/ci-contributor.yml
+++ b/.github/workflows/ci-contributor.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install backend dependencies (edit as needed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -275,7 +275,7 @@ jobs:
           echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/.github/workflows/cross-platform-compat.yml
+++ b/.github/workflows/cross-platform-compat.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Validate backend requirements lock sync

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,11 +26,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # --- 1.2 BACKEND SETUP & LINT ---
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13"
 

--- a/.github/workflows/security-test-lane.yml
+++ b/.github/workflows/security-test-lane.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary
- Upgrade actions/setup-python from v4 to v5 in active CI workflows
- Upgrade actions/checkout from v3 to v4 in python-app workflow
- Keep workflow behavior unchanged while removing older action pins

## Related issue(s)
Closes #374
Refs #156

## Validation
- Verified no remaining uses of actions/setup-python@v4
- Verified no remaining uses of actions/checkout@v3