### PR TITLE
chore(agent-catalog): roll consumer to v0.1.1 with PR closeout agent

### DIFF
--- a/.github/agents/pr-closeout-orchestrator.agent.md
+++ b/.github/agents/pr-closeout-orchestrator.agent.md
@@ -1,0 +1,37 @@
+---
+description: "Use when a pull request is near merge and needs deterministic closeout: refresh checks, identify failing gates, resolve review-thread debt, and produce merge readiness verdicts with concrete next actions."
+name: "PR Closeout Orchestrator"
+tools: [read, search, execute]
+user-invocable: true
+argument-hint: "Provide PR number/branch and whether to run full closeout (checks, thread status, merge readiness) or targeted diagnostics."
+---
+You are a PR closeout specialist. Your job is to drive a pull request to a reliable merge-ready state with evidence.
+
+## Objectives
+- Confirm the PR head is current with target branch policy.
+- Collect check statuses and classify: passing, pending, failed, neutral.
+- Enumerate unresolved review threads and comment debt.
+- Produce a clear merge readiness verdict: ready, blocked, or waiting.
+
+## Required Workflow
+1. Confirm working branch and PR identity.
+2. Refresh PR metadata and status checks from GitHub.
+3. If checks failed, isolate root cause and run only targeted local validation for impacted scope.
+4. If review threads are open and already addressed in code, resolve those threads.
+5. Re-check status after any push/update and report deltas.
+6. End with an evidence-backed readiness decision.
+
+## Constraints
+- Do not claim success while required checks are pending or failing.
+- Do not resolve threads unless the underlying issue is fixed or explicitly accepted by maintainers.
+- Do not mix unrelated file changes into closeout commits.
+- Prefer smallest safe fixes and immediate retest of impacted areas.
+
+## Output Format
+Return results in this order:
+1. PR Snapshot
+2. Check Matrix
+3. Review Thread Status
+4. Actions Applied
+5. Readiness Verdict
+6. Next Commands

--- a/.github/workflows/agent-catalog-guard.yml
+++ b/.github/workflows/agent-catalog-guard.yml
@@ -53,7 +53,7 @@ jobs:
             throw "Unexpected sourceRepo: $($lock.sourceRepo)"
           }
 
-          if ($lock.ref -ne "v0.1.0") {
+          if ($lock.ref -ne "v0.1.1") {
             throw "Unexpected ref: $($lock.ref)"
           }
 

--- a/AGENT_CATALOG_PLAN.md
+++ b/AGENT_CATALOG_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This repo is enrolled as a consumer of `NPGrant81/agent-catalog@v0.1.0` using local control surfaces only.
+This repo is enrolled as a consumer of `NPGrant81/agent-catalog@v0.1.1` using local control surfaces only.
 
 Included in this slice:
 
@@ -21,7 +21,7 @@ Excluded from this slice:
 
 The repo is enrolled with non-deferred sync enabled.
 
-- Approved source `NPGrant81/agent-catalog@v0.1.0` is available locally.
+- Approved source `NPGrant81/agent-catalog@v0.1.1` is available locally.
 - Local sync validates configuration and materializes only lock-managed payloads.
 - Managed payloads are copied from source and not fabricated locally.
 
@@ -36,14 +36,14 @@ Catalog owns `.github/agents/*.agent.md` in active mode.
 
 Unlock condition is satisfied.
 
-1. catalog source for `NPGrant81/agent-catalog@v0.1.0` is available to the local operator
+1. catalog source for `NPGrant81/agent-catalog@v0.1.1` is available to the local operator
 2. deferred mode was removed by approved follow-up work
 
 ## First Real Sync Path
 
 Executed path:
 
-1. approved source access was provided for `NPGrant81/agent-catalog@v0.1.0`
+1. approved source access was provided for `NPGrant81/agent-catalog@v0.1.1`
 2. `sync_agents.ps1` now materializes only managed payloads declared in the lock file
 3. guard-equivalent path and active sync were re-run in non-deferred mode
 

--- a/agent_catalog.lock.json
+++ b/agent_catalog.lock.json
@@ -1,18 +1,19 @@
 {
   "schemaVersion": 1,
   "sourceRepo": "NPGrant81/agent-catalog",
-  "ref": "v0.1.0",
+  "ref": "v0.1.1",
   "deferred": false,
   "enabled": true,
   "status": "active-synced-from-approved-source",
   "managedAgents": [
     "architecture-drift-auditor.agent.md",
     "governance-cadence.agent.md",
+    "pr-closeout-orchestrator.agent.md",
     "quality-integrity-checker.agent.md",
     "scope-triage.agent.md"
   ],
   "notes": [
-    "Consumer sync is enabled from approved source NPGrant81/agent-catalog@v0.1.0.",
+    "Consumer sync is enabled from approved source NPGrant81/agent-catalog@v0.1.1.",
     "Only managed payloads listed in managedAgents are materialized into .github/agents.",
     "Managed payloads are copied from catalog source without local fabrication."
   ]

--- a/sync_agents.ps1
+++ b/sync_agents.ps1
@@ -93,7 +93,7 @@ function Assert-LockShape($Lock) {
         Fail "Unexpected sourceRepo in lock file: $($Lock.sourceRepo)"
     }
 
-    if ($Lock.ref -ne "v0.1.0") {
+    if ($Lock.ref -ne "v0.1.1") {
         Fail "Unexpected ref in lock file: $($Lock.ref)"
     }
 


### PR DESCRIPTION
## Summary
- bump consumer catalog ref from `v0.1.0` to `v0.1.1`
- add managed payload `.github/agents/pr-closeout-orchestrator.agent.md`
- align lock/script/workflow ref expectations to `v0.1.1`
- keep catalog-owned managed sync contract intact

## Files Changed
- `agent_catalog.lock.json`
- `AGENT_CATALOG_PLAN.md`
- `sync_agents.ps1`
- `.github/workflows/agent-catalog-guard.yml`
- `.github/agents/pr-closeout-orchestrator.agent.md`

## Validation
- `./sync_agents.ps1 -Check` passed
- local sync materialized 5 managed agents including `pr-closeout-orchestrator.agent.md`

## Notes
- `sync_agents.ps1` version bump (`v0.1.0` -> `v0.1.1`) was inspected and intentionally preserved as policy alignment, not formatting noise.